### PR TITLE
:sparkles: new interface

### DIFF
--- a/.github/workflows/ci-tsdownsample.yml
+++ b/.github/workflows/ci-tsdownsample.yml
@@ -88,7 +88,7 @@ jobs:
   # Perhaps smth more in line with this https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
     name: build on ${{ matrix.os }} (${{ matrix.target }} - ${{ matrix.manylinux || 'auto' }})
     # only run on push to main and on release
-    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build'))"
+    # if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build'))"
     strategy:
       fail-fast: false
       matrix:
@@ -167,7 +167,7 @@ jobs:
 
   Release:
     needs: [Lint_and_Check, Test, Build]
-    if: "success() && startsWith(github.ref, 'refs/tags/')"
+    # if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-tsdownsample.yml
+++ b/.github/workflows/ci-tsdownsample.yml
@@ -88,7 +88,7 @@ jobs:
   # Perhaps smth more in line with this https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
     name: build on ${{ matrix.os }} (${{ matrix.target }} - ${{ matrix.manylinux || 'auto' }})
     # only run on push to main and on release
-    # if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build'))"
+    if: "success() && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build'))"
     strategy:
       fail-fast: false
       matrix:
@@ -167,7 +167,7 @@ jobs:
 
   Release:
     needs: [Lint_and_Check, Test, Build]
-    # if: "success() && startsWith(github.ref, 'refs/tags/')"
+    if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/*
 venv/
 TODO.md
 main.rs

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ black = black tsdownsample tests
 install:
 	pip install -e .
 
+.PHONY: install-dev-requirements
+install-dev-requirements:
+	pip install -r tests/requirements.txt
+	pip install -r tests/requirements-linting.txt
+
 .PHONY: format
 format:
 	$(isort)

--- a/README.md
+++ b/README.md
@@ -48,14 +48,13 @@ pip install tsdownsample
 
 ```python
 from tsdownsample import MinMaxLTTBDownsampler
-import pandas as pd; import numpy as np
+import numpy as np
 
 # Create a time series
 y = np.random.randn(10_000_000)
-s = pd.Series(y)
 
 # Downsample to 1000 points
-s_ds = MinMaxLTTBDownsampler.downsample(s, n_out=1000)
+s_ds = MinMaxLTTBDownsampler().downsample(y, n_out=1000)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![PyPI Latest Release](https://img.shields.io/pypi/v/tsdownsample.svg)](https://pypi.org/project/tsdownsample/)
 [![support-version](https://img.shields.io/pypi/pyversions/tsdownsample)](https://img.shields.io/pypi/pyversions/tsdownsample)
 [![Downloads](https://pepy.tech/badge/tsdownsample)](https://pepy.tech/project/tsdownsample)
-<!-- [![Testing](https://github.com/predict-idlab/tsflex/actions/workflows/test.yml/badge.svg)](https://github.com/predict-idlab/tsflex/actions/workflows/test.yml) -->
+[![Testing](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-downsample_rs.yml/badge.svg)](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-downsample_rs.yml)
+[![Testing](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-tsdownsample.yml/badge.svg)](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-tsdownsample.yml)
+<!-- TODO: codecov -->
 
 **📈 Time series downsampling** algorithms for visualization
 
@@ -29,7 +31,7 @@
     <details>
       <summary><i>!! 🚀 <code>f16</code> <a href="https://github.com/jvdd/argminmax">argminmax</a> is 200-300x faster than numpy</i></summary>
       In contrast with all other data types above, <code>f16</code> is *not* hardware supported (i.e., no instructions for f16) by most modern CPUs!! <br>
-      🐌 Programming languages facilitate support for this datatype by either (i) upcasting to `f32` or (ii) using a software implementation. <br>
+      🐌 Programming languages facilitate support for this datatype by either (i) upcasting to <u>f32</u> or (ii) using a software implementation. <br>
       💡 As for argminmax, only comparisons are needed - and thus no arithmetic operations - creating a <u>symmetrical ordinal mapping from <code>f16</code> to <code>i16</code></u> is sufficient. This mapping allows to use the hardware supported scalar and SIMD <code>i16</code> instructions - while not producing any memory overhead 🎉 <br>
       <i>More details are described in <a href="https://github.com/jvdd/argminmax/pull/1">argminmax PR #1</a>.</i>
     </details>
@@ -37,7 +39,7 @@
 
 ## Install
 
-> ❗🚨❗ This package is currently under development - no stable release yet ❗🚨❗
+> ❗🚨❗ This package is currently under development - API is not yet fixed ❗🚨❗
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## Install
 
-<!-- > ❗🚨❗ This package is currently under development - API is not yet fixed ❗🚨❗ -->
+> ❗🚨❗ This package is currently under development - correct installation is not yet guaranteed ❗🚨❗
 
 ```bash
 pip install tsdownsample
@@ -55,10 +55,20 @@ import numpy as np
 
 # Create a time series
 y = np.random.randn(10_000_000)
+x = np.arange(len(y))
 
-# Downsample to 1000 points
+# Downsample to 1000 points (assuming constant sampling rate)
 s_ds = MinMaxLTTBDownsampler().downsample(y, n_out=1000)
+
+# Downsample to 1000 points using the (possible irregularly spaced) x-data
+s_ds = MinMaxLTTBDownsampler().downsample(x, y, n_out=1000)
 ```
+
+## Limitations
+
+Assumes;
+(i) x-data monotinically increasing (i.e., sorted)
+(ii) no NaNs in the data
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@
   - works on views of the data (no copies)
   - no intermediate data structures are created
 * **Flexible**: works on any type of data
-    - supported datatypes are `f16`, `f32`, `f64`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64`
+    - supported datatypes are 
+      - for `x`: `f16`, `f32`, `f64`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64`, `datetime64`
+      - for `y`: `f16`, `f32`, `f64`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`
     <details>
       <summary><i>!! 🚀 <code>f16</code> <a href="https://github.com/jvdd/argminmax">argminmax</a> is 200-300x faster than numpy</i></summary>
       In contrast with all other data types above, <code>f16</code> is *not* hardware supported (i.e., no instructions for f16) by most modern CPUs!! <br>
@@ -39,8 +41,7 @@
 
 ## Install
 
-> ❗🚨❗ This package is currently under development - API is not yet fixed ❗🚨❗
-
+<!-- > ❗🚨❗ This package is currently under development - API is not yet fixed ❗🚨❗ -->
 
 ```bash
 pip install tsdownsample

--- a/downsample_rs/Cargo.toml
+++ b/downsample_rs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 ndarray = {version = "0.15.6", default-features = false, features = ["rayon"] }
-argminmax = { version = "0.2.1" , features = ["half"] }
+argminmax = { version = "0.3" , features = ["half"] }
 half = { version = "2.1", default-features = false , optional = true}
 
 [dev-dependencies]

--- a/downsample_rs/src/lttb/scalar.rs
+++ b/downsample_rs/src/lttb/scalar.rs
@@ -23,21 +23,24 @@ pub fn lttb<Tx: Num, Ty: Num>(x: ArrayView1<Tx>, y: ArrayView1<Ty>, n_out: usize
 
     for i in 0..n_out - 2 {
         // Calculate point average for next bucket (containing c).
-        let mut avg_x: Tx = Tx::default();
-        let mut avg_y: Ty = Ty::default();
+        // let mut avg_x: Tx = Tx::default();
+        // let mut avg_y: Ty = Ty::default();
+        // TODO: check the impact of using f64 (is necessary to avoid overflow)
+        let mut avg_x: f64 = 0.0;
+        let mut avg_y: f64 = 0.0;
 
         let avg_range_start = (every * (i + 1) as f64) as usize + 1;
         let avg_range_end = cmp::min((every * (i + 2) as f64) as usize + 1, x.len());
 
         for i in avg_range_start..avg_range_end {
-            avg_x = avg_x + x[i];
-            avg_y = avg_y + y[i];
+            avg_x = avg_x + x[i].to_f64();
+            avg_y = avg_y + y[i].to_f64();
         }
         // Slicing seems to be a lot slower
         // let avg_x: Tx = x.slice(s![avg_range_start..avg_range_end]).sum();
         // let avg_y: Ty = y.slice(s![avg_range_start..avg_range_end]).sum();
-        let avg_x: f64 = avg_x.to_f64() / (avg_range_end - avg_range_start) as f64;
-        let avg_y: f64 = avg_y.to_f64() / (avg_range_end - avg_range_start) as f64;
+        let avg_x: f64 = avg_x / (avg_range_end - avg_range_start) as f64;
+        let avg_y: f64 = avg_y / (avg_range_end - avg_range_start) as f64;
 
         // Get the range for this bucket
         let range_offs = (every * i as f64) as usize + 1;
@@ -93,17 +96,19 @@ pub fn lttb_without_x<Ty: Num>(y: ArrayView1<Ty>, n_out: usize) -> Array1<usize>
 
     for i in 0..n_out - 2 {
         // Calculate point average for next bucket (containing c).
-        let mut avg_y: Ty = Ty::default();
+        // let mut avg_y: Ty = Ty::default();
+        // TODO: check impact of using f64 (is necessary to avoid overflow)
+        let mut avg_y: f64 = 0.0;
 
         let avg_range_start = (every * (i + 1) as f64) as usize + 1;
         let avg_range_end = cmp::min((every * (i + 2) as f64) as usize + 1, y.len());
 
         for i in avg_range_start..avg_range_end {
-            avg_y = avg_y + y[i];
+            avg_y = avg_y + y[i].to_f64();
         }
         // Slicing seems to be a lot slower
         // let avg_x: Tx = x.slice(s![avg_range_start..avg_range_end]).sum();
-        let avg_y: f64 = avg_y.to_f64() / (avg_range_end - avg_range_start) as f64;
+        let avg_y: f64 = avg_y / (avg_range_end - avg_range_start) as f64;
         let avg_x: f64 = (avg_range_start + avg_range_end - 1) as f64 / 2.0;
 
         // Get the range for this bucket

--- a/downsample_rs/src/utils.rs
+++ b/downsample_rs/src/utils.rs
@@ -1,0 +1,294 @@
+use ndarray::Array1;
+use ndarray::ArrayView1;
+
+use rayon::prelude::*;
+use std::ops::{Add, Div, Sub, Mul};
+
+pub trait FromUsize {
+    fn from_usize(value: usize) -> Self;
+}
+
+macro_rules! impl_from_usize {
+    ($($t:ty),*) => {
+        $(
+            impl FromUsize for $t {
+                #[inline]
+                fn from_usize(value: usize) -> Self {
+                    value as Self
+                }
+            }
+        )*
+    };
+}
+
+impl_from_usize!(f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, usize);
+
+#[inline(always)]
+fn binary_search<T: PartialOrd>(arr: ArrayView1<T>, value: T, left: usize, right: usize) -> usize {
+    let mut size: usize = right - left;
+    let mut left: usize = left;
+    let mut right: usize = right;
+    // Return the index where the value is <= arr[index] and arr[index+1] < value
+    while left < right {
+        let mid = left + size / 2;
+        if arr[mid] < value {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+        size = right - left;
+    }
+    left
+}
+
+#[inline(always)]
+fn binary_search_with_mid<T: PartialOrd>(
+    arr: ArrayView1<T>,
+    value: T,
+    left: usize,
+    right: usize,
+    mid: usize,
+) -> usize {
+    assert!(mid >= left || mid <= right);
+    let mut left: usize = left;
+    let mut right: usize = right;
+    let mut mid: usize = mid;
+    // Return the index where the value is <= arr[index] and arr[index+1] < value
+    while left < right {
+        if arr[mid] < value {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+        let size = right - left;
+        mid = left + size / 2;
+    }
+    left
+}
+
+pub fn get_equidistant_bin_idxs<T>(arr: ArrayView1<T>, nb_bins: usize) -> Array1<usize>
+where
+    T: PartialOrd
+        + Copy
+        + Sub<Output = T>
+        + Add<Output = T>
+        + Div<Output = T>
+        // + std::convert::From<usize>,
+        + FromUsize,
+{
+    assert!(nb_bins >= 2);
+    let mut bin_idxs: Array1<usize> = Array1::zeros(nb_bins - 1);
+    // Divide by nb_bins to avoid overflow!
+    let val_step: T = (arr[arr.len() - 1] / FromUsize::from_usize(nb_bins)) - (arr[0] / FromUsize::from_usize(nb_bins));
+    let idx_step: usize = arr.len() / nb_bins;
+    let mut value = arr[0];
+    let mut idx = 0;
+    for i in 0..nb_bins-1 {
+        value = value + val_step;
+        let mid = idx + idx_step;
+        let mid = if mid < arr.len() { mid } else { arr.len() - 1 };
+        // Implementation WITHOUT pre-guessing mid is slower!!
+        // idx = binary_search(arr, value, idx, arr.len()-1);
+        idx = binary_search_with_mid(arr, value, idx, arr.len() - 1, mid);
+        bin_idxs[i] = idx;
+    }
+    bin_idxs
+}
+
+// #[inline(always)]
+fn sequential_add_mul<T: Copy + Add<Output = T> + Mul<Output = T> + FromUsize>(
+    start_val: T,
+    add_val: T,
+    mul: usize,
+) -> T 
+{
+    // a + x*b will sometimes overflow when x*b is larger than the largest positive 
+    // number in the datatype.
+    // This code should not fail when: (T::MAX - a) < (x*b).
+    let mul_2: usize = mul / 2;
+    start_val + add_val * FromUsize::from_usize(mul_2) + add_val * FromUsize::from_usize(mul - mul_2)
+}
+
+pub fn get_equidistant_bin_idxs_parallel<T>(arr: ArrayView1<T>, nb_bins: usize) -> Array1<usize>
+where
+    T: PartialOrd
+        + Copy
+        + Sub<Output = T>
+        + Add<Output = T>
+        + Div<Output = T>
+        + Mul<Output = T>
+        + Send
+        + Sync
+        + FromUsize,
+{
+    assert!(nb_bins >= 2);
+    let mut bin_idxs: Array1<usize> = Array1::from((1..nb_bins).collect::<Vec<usize>>());
+    // Divide by nb_bins to avoid overflow!
+    let val_step: T = (arr[arr.len() - 1] / FromUsize::from_usize(nb_bins)) - (arr[0] / FromUsize::from_usize(nb_bins));
+    // let idx_step: usize = arr.len() / nb_bins;
+    bin_idxs.par_iter_mut().for_each(|i| {
+        let value = sequential_add_mul(arr[0], val_step, *i); 
+        *i = binary_search(arr, value, 0, arr.len() - 1);
+        // Implementation WITH pre-guessing mid is slower!!
+        // *i = binary_search_with_mid(arr, value, 0, arr.len() - 1, *i * idx_step);
+    });
+    bin_idxs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::Array1;
+
+   extern crate dev_utils;
+    use dev_utils::utils::get_random_array;
+
+    #[test]
+    fn test_binary_search() {
+        let arr = Array1::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(binary_search(arr.view(), 0, 0, arr.len() - 1), 0);
+        assert_eq!(binary_search(arr.view(), 1, 0, arr.len() - 1), 0);
+        assert_eq!(binary_search(arr.view(), 2, 0, arr.len() - 1), 1);
+        assert_eq!(binary_search(arr.view(), 3, 0, arr.len() - 1), 2);
+        assert_eq!(binary_search(arr.view(), 4, 0, arr.len() - 1), 3);
+        assert_eq!(binary_search(arr.view(), 5, 0, arr.len() - 1), 4);
+        assert_eq!(binary_search(arr.view(), 6, 0, arr.len() - 1), 5);
+        assert_eq!(binary_search(arr.view(), 7, 0, arr.len() - 1), 6);
+        assert_eq!(binary_search(arr.view(), 8, 0, arr.len() - 1), 7);
+        assert_eq!(binary_search(arr.view(), 9, 0, arr.len() - 1), 8);
+        assert_eq!(binary_search(arr.view(), 10, 0, arr.len() - 1), 9);
+        assert_eq!(binary_search(arr.view(), 11, 0, arr.len() - 1), 9);
+    }
+
+    #[test]
+    fn test_binary_search_with_mid() {
+        let arr = Array1::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert_eq!(binary_search_with_mid(arr.view(), 0, 0, arr.len() - 1, 0), 0);
+        assert_eq!(binary_search_with_mid(arr.view(), 1, 0, arr.len() - 1, 0), 0);
+        assert_eq!(binary_search_with_mid(arr.view(), 2, 0, arr.len() - 1, 1), 1);
+        assert_eq!(binary_search_with_mid(arr.view(), 3, 0, arr.len() - 1, 2), 2);
+        assert_eq!(binary_search_with_mid(arr.view(), 4, 0, arr.len() - 1, 3), 3);
+        assert_eq!(binary_search_with_mid(arr.view(), 5, 0, arr.len() - 1, 4), 4);
+        assert_eq!(binary_search_with_mid(arr.view(), 6, 0, arr.len() - 1, 5), 5);
+        assert_eq!(binary_search_with_mid(arr.view(), 7, 0, arr.len() - 1, 6), 6);
+        assert_eq!(binary_search_with_mid(arr.view(), 8, 0, arr.len() - 1, 7), 7);
+        assert_eq!(binary_search_with_mid(arr.view(), 9, 0, arr.len() - 1, 8), 8);
+        assert_eq!(binary_search_with_mid(arr.view(), 10, 0, arr.len() - 1, 9), 9);
+        // This line causes the code to crash -> because value higher than arr[mid]
+        // assert_eq!(binary_search_with_mid(arr.view(), 11, 0, arr.len() - 1, 9), 9);
+    }
+
+    #[test]
+    fn test_get_equidistant_bin_idxs() {
+        let arr = Array1::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let bin_idxs = get_equidistant_bin_idxs(arr.view(), 3);
+        assert_eq!(bin_idxs, Array1::from(vec![3, 6]));
+        let bin_idxs = get_equidistant_bin_idxs_parallel(arr.view(), 3);
+        assert_eq!(bin_idxs, Array1::from(vec![3, 6]));
+    }
+
+    #[test]
+    fn test_many_random_same_result() {
+        let n = 5_000;
+        let nb_bins = 100;
+        for _ in (0..100) {
+            let arr = get_random_array::<i32>(n, i32::MIN, i32::MAX);
+            // Sort the array
+            let mut arr = arr.to_vec();
+            arr.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let arr = Array1::from(arr);
+            // Calculate the bin indexes
+            let bin_idxs = get_equidistant_bin_idxs(arr.view(), nb_bins);
+            let bin_idxs_parallel = get_equidistant_bin_idxs_parallel(arr.view(), nb_bins);
+            assert_eq!(bin_idxs, bin_idxs_parallel);
+        }
+    }
+}
+
+// use std::convert::{ TryFrom, TryInto };
+
+// // Divide and conquer algorithm
+// pub fn get_equidistant_bin_idxs_dc<T>(
+//     arr: ArrayView1<T>,
+//     nb_bins: usize,
+// ) -> Array1<usize>
+// where
+//     T: PartialOrd + Copy + Sub<Output = T> + Add<Output = T> + Div<Output = T> + std::convert::From<usize> + Mul<Output = T> + Rem<Output = T>,
+//     usize: std::convert::From<T>
+// {
+//     let mut bin_idxs: Array1<usize> = Array1::from((0..nb_bins).collect::<Vec<usize>>());
+//     let val_step: T = (arr[arr.len() - 1] - arr[0]) / nb_bins.try_into().unwrap();
+//     dnc_loop(arr, val_step, &mut bin_idxs, 0, arr.len() - 1, 0);
+//     bin_idxs
+// }
+
+// fn dnc_loop<T>(
+//     arr: ArrayView1<T>,
+//     val_step: T,
+//     bin_idxs: &mut Array1<usize>,
+//     left: usize,
+//     right: usize,
+//     insert_idx: usize,
+// )
+// where
+//     T: PartialOrd + Copy + Sub<Output = T> + Add<Output = T> + Div<Output = T> + std::convert::From<usize> + Mul<Output = T> + Rem<Output = T>,
+//     usize: std::convert::From<T>
+// {
+//     // Base case: only 1 search value between left and right
+//     let val_left = arr[left];
+//     let val_right = arr[right];
+//     let diff = (val_right / val_step) - (val_left / val_step);
+//     // Convert to usize
+//     let diff: usize = usize::try_from(diff).unwrap();
+//     if diff == 0 {
+//         return;
+//     }
+//     else if diff == 1 {
+//         // println!("left: {}, right: {}, insert_idx: {}", left, right, insert_idx);
+//         let search_val = val_right - (val_right % val_step);
+//         bin_idxs[insert_idx] = binary_search(arr, search_val, left, right);
+//         return;
+//     } else {
+//         let mid = (left + right) / 2;
+//         dnc_loop(arr, val_step, bin_idxs, left, mid, insert_idx);
+//         dnc_loop(arr, val_step, bin_idxs, mid+1, right, insert_idx + diff / 2);
+//     }
+// }
+
+// // Divide and conquer algorithm - iterative version
+// pub fn get_equidistant_bin_idxs_dc_iterative<T>(
+//     arr: ArrayView1<T>,
+//     nb_bins: usize,
+// ) -> Array1<usize>
+// where
+//     T: PartialOrd + Copy + Sub<Output = T> + Add<Output = T> + Div<Output = T> + std::convert::From<usize> + Mul<Output = T> + Rem<Output = T>,
+//     usize: std::convert::From<T>
+// {
+//     let mut bin_idxs: Array1<usize> = Array1::from((0..nb_bins).collect::<Vec<usize>>());
+//     let val_step: T = (arr[arr.len() - 1] - arr[0]) / nb_bins.try_into().unwrap();
+//     let mut stack: Vec<(usize, usize, usize)> = Vec::new();
+//     stack.push((0, arr.len() - 1, 0));
+//     while !stack.is_empty() {
+//         let (left, right, insert_idx) = stack.pop().unwrap();
+//         // Base case: only 1 search value between left and right
+//         let val_left = arr[left];
+//         let val_right = arr[right];
+//         let diff = (val_right / val_step) - (val_left / val_step);
+//         // Convert to usize
+//         let diff: usize = usize::try_from(diff).unwrap();
+//         if diff == 0 {
+//             continue;
+//         }
+//         else if diff == 1 {
+//             // println!("left: {}, right: {}, insert_idx: {}", left, right, insert_idx);
+//             let search_val = val_right - (val_right % val_step);
+//             bin_idxs[insert_idx] = binary_search(arr, search_val, left, right);
+//             continue;
+//         } else {
+//             let mid = (left + right) / 2;
+//             stack.push((left, mid, insert_idx));
+//             stack.push((mid+1, right, insert_idx + diff / 2));
+//         }
+//     }
+//     bin_idxs
+// }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "tsdownsample"
 description = "Time series downsampling in rust"
-version = "0.1.0a4"
+version = "0.1.0a5"
 requires-python = ">=3.7"
 dependencies = ["numpy"]
 authors = [{name = "Jeroen Van Der Donckt"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tsdownsample"
 description = "Time series downsampling in rust"
 version = "0.1.0a4"
 requires-python = ">=3.7"
-dependencies = ["numpy", "pandas"]
+dependencies = ["numpy"]
 authors = [{name = "Jeroen Van Der Donckt"}]
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,10 +114,15 @@ macro_rules! _create_pyfunc_with_x_with_ratio {
 }
 
 macro_rules! _create_pyfuncs_with_x_generic {
-    ($create_macro:ident, $resample_mod:ident, $resample_fn:ident, $mod:ident, $($t:ty)+) => {
-        // The macro will implement the function for all combinations of $t (for type x and y).
-        // (duplicate the list of types to iterate over all combinations)
-        _create_pyfuncs_with_x_generic!(@inner $create_macro, $resample_mod, $resample_fn, $mod, $($t)+; $($t),+);
+    // ($create_macro:ident, $resample_mod:ident, $resample_fn:ident, $mod:ident, $($t:ty)+) => {
+    //     // The macro will implement the function for all combinations of $t (for type x and y).
+    //     // (duplicate the list of types to iterate over all combinations)
+    //     _create_pyfuncs_with_x_generic!(@inner $create_macro, $resample_mod, $resample_fn, $mod, $($t)+; $($t),+);
+    // };
+
+    ($create_macro:ident, $resample_mod:ident, $resample_fn:ident, $mod:ident, $($tx:ty)+, $($ty:ty)+) => {
+        // The macro will implement the function for all combinations of $tx and $ty (for respectively type x and y).
+        _create_pyfuncs_with_x_generic!(@inner $create_macro, $resample_mod, $resample_fn, $mod, $($tx)+; $($ty),+);
     };
 
     // Base case: there is only one type (for y) left
@@ -142,25 +147,25 @@ macro_rules! _create_pyfuncs_with_x_generic {
 
 macro_rules! create_pyfuncs_without_x {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_without_x_generic!(_create_pyfunc_without_x, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64);
+        _create_pyfuncs_without_x_generic!(_create_pyfunc_without_x, $resample_mod, $resample_fn, $mod, f16 f32 f64 i8 i16 i32 i64 u8 u16 u32 u64);
     };
 }
 
 macro_rules! create_pyfuncs_without_x_with_ratio {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_without_x_generic!(_create_pyfunc_without_x_with_ratio, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64);
+        _create_pyfuncs_without_x_generic!(_create_pyfunc_without_x_with_ratio, $resample_mod, $resample_fn, $mod, f16 f32 f64 i8 i16 i32 i64 u8 u16 u32 u64);
     };
 }
 
 macro_rules! create_pyfuncs_with_x {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_with_x_generic!(_create_pyfunc_with_x, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64);
+        _create_pyfuncs_with_x_generic!(_create_pyfunc_with_x, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64, f16 f32 f64 i8 i16 i32 i64 u8 u16 u32 u64);
     };
 }
 
 macro_rules! create_pyfuncs_with_x_with_ratio {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_with_x_generic!(_create_pyfunc_with_x_with_ratio, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64);
+        _create_pyfuncs_with_x_generic!(_create_pyfunc_with_x_with_ratio, $resample_mod, $resample_fn, $mod, f16 f32 f64 i16 i32 i64 u16 u32 u64, f16 f32 f64 i8 i16 i32 i64 u8 u16 u32 u64);
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@ extern crate downsample_rs;
 extern crate paste;
 
 // TODO
-// - support bool
-//      => issue: does not have to_primitive (necessary for lttb)
 // - m4 & minmax should determine bin size on x-range!
 //      code now assumes equal bin size
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,12 @@ _core_supported_dtypes = [
 ]
 
 supported_dtypes_x = _core_supported_dtypes
-supported_dtypes_y = _core_supported_dtypes + [np.int8, np.uint8, np.bool8]
+supported_dtypes_y = _core_supported_dtypes + [
+    np.timedelta64,
+    np.int8,
+    np.uint8,
+    np.bool8,
+]
 
 _core_rust_primitive_types = [
     "f16",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,33 @@
+# Store some global configuration for tests
+
+import numpy as np
+
+_core_supported_dtypes = [
+    np.float16,
+    np.float32,
+    np.float64,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+]
+
+supported_dtypes_x = _core_supported_dtypes + [np.datetime64]
+supported_dtypes_y = _core_supported_dtypes + [np.int8, np.uint8, np.bool8]
+
+_core_rust_primitive_types = [
+    "f16",
+    "f32",
+    "f64",
+    "i16",
+    "i32",
+    "i64",
+    "u16",
+    "u32",
+    "u64",
+]
+
+rust_primitive_types_x = _core_rust_primitive_types
+rust_primitive_types_y = _core_rust_primitive_types + ["i8", "u8"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,9 +12,10 @@ _core_supported_dtypes = [
     np.uint16,
     np.uint32,
     np.uint64,
+    np.datetime64,
 ]
 
-supported_dtypes_x = _core_supported_dtypes + [np.datetime64]
+supported_dtypes_x = _core_supported_dtypes
 supported_dtypes_y = _core_supported_dtypes + [np.int8, np.uint8, np.bool8]
 
 _core_rust_primitive_types = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,15 +13,11 @@ _core_supported_dtypes = [
     np.uint32,
     np.uint64,
     np.datetime64,
+    np.timedelta64,
 ]
 
 supported_dtypes_x = _core_supported_dtypes
-supported_dtypes_y = _core_supported_dtypes + [
-    np.timedelta64,
-    np.int8,
-    np.uint8,
-    np.bool8,
-]
+supported_dtypes_y = _core_supported_dtypes + [np.int8, np.uint8, np.bool8]
 
 _core_rust_primitive_types = [
     "f16",

--- a/tests/test_rust_mods.py
+++ b/tests/test_rust_mods.py
@@ -1,6 +1,6 @@
-import tsdownsample._rust._tsdownsample_rs as tsds_rs
+from test_config import rust_primitive_types_x, rust_primitive_types_y
 
-DTYPES = ["f16", "f32", "f64", "i16", "i32", "i64", "u16", "u32", "u64"]
+import tsdownsample._rust._tsdownsample_rs as tsds_rs
 
 
 def _test_rust_mod_correctly_build(mod, sub_mods, has_x_impl: bool):
@@ -8,7 +8,7 @@ def _test_rust_mod_correctly_build(mod, sub_mods, has_x_impl: bool):
     for sub_mod in sub_mods:
         assert hasattr(mod, sub_mod)
         m = getattr(mod, sub_mod)
-        for ty in DTYPES:
+        for ty in rust_primitive_types_y:
             assert hasattr(m, f"downsample_{ty}")
     # With x
     if not has_x_impl:
@@ -16,8 +16,8 @@ def _test_rust_mod_correctly_build(mod, sub_mods, has_x_impl: bool):
     for sub_mod in sub_mods:
         assert hasattr(mod, sub_mod)
         m = getattr(mod, sub_mod)
-        for tx in DTYPES:
-            for ty in DTYPES:
+        for tx in rust_primitive_types_x:
+            for ty in rust_primitive_types_y:
                 assert hasattr(m, f"downsample_{tx}_{ty}")
 
 

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -1,12 +1,10 @@
-import pytest
 import numpy as np
+import pytest
 
-from tsdownsample import (
+from tsdownsample import (  # MeanDownsampler,; MedianDownsampler,
     EveryNthDownsampler,
     LTTBDownsampler,
     M4Downsampler,
-    # MeanDownsampler,
-    # MedianDownsampler,
     MinMaxDownsampler,
     MinMaxLTTBDownsampler,
 )
@@ -96,7 +94,9 @@ def test_parallel_downsampling():
         s_downsampled_p = downsampler.downsample(arr, n_out=100, parallel=True)
         assert np.all(s_downsampled == s_downsampled_p)
 
+
 ## Using x
+
 
 def test_downsampling_with_x():
     """Test downsampling with x."""
@@ -134,6 +134,7 @@ def test_downsampling_different_dtypes():
     for i in range(1, len(res)):
         assert np.all(res[0] == res[i])
 
+
 def test_downsampling_different_dtypes_with_x():
     """Test downsampling with different data types."""
     arr_orig = np.random.randint(0, 100, size=10_000)
@@ -148,7 +149,9 @@ def test_downsampling_different_dtypes_with_x():
         for i in range(1, len(res)):
             assert np.all(res[0] == res[i])
 
+
 ### Unsupported dtype
+
 
 def test_error_unsupported_dtype():
     """Test unsupported dtype."""
@@ -156,6 +159,7 @@ def test_error_unsupported_dtype():
     arr = arr.astype(np.bool)
     with pytest.raises(ValueError):
         MinMaxDownsampler().downsample(arr, n_out=100)
+
 
 def test_error_invalid_args():
     """Test invalid arguments."""
@@ -174,7 +178,9 @@ def test_error_invalid_args():
     assert "y must be 1D" in str(e_msg.value)
     # Invalid x
     with pytest.raises(ValueError) as e_msg:
-        MinMaxDownsampler().downsample(arr.reshape(5, 2_000), arr, n_out=100, parallel=True)
+        MinMaxDownsampler().downsample(
+            arr.reshape(5, 2_000), arr, n_out=100, parallel=True
+        )
     assert "x must be 1D" in str(e_msg.value)
     # Invalid x and y (different length)
     with pytest.raises(ValueError) as e_msg:

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -5,8 +5,8 @@ from tsdownsample import (
     EveryNthDownsampler,
     LTTBDownsampler,
     M4Downsampler,
-    MeanDownsampler,
-    MedianDownsampler,
+    # MeanDownsampler,
+    # MedianDownsampler,
     MinMaxDownsampler,
     MinMaxLTTBDownsampler,
 )
@@ -24,7 +24,7 @@ def test_m4_downsampler():
     """Test M4 downsampler."""
     arr = np.array(np.arange(10_000))
     s = pd.Series(arr)
-    s_downsampled = M4Downsampler.downsample(s, 100)
+    s_downsampled = M4Downsampler().downsample(s, 100)
     assert s_downsampled.values[0] == 0
     assert s_downsampled.values[-1] == len(arr) - 1
 
@@ -33,7 +33,7 @@ def test_minmax_downsampler():
     """Test MinMax downsampler."""
     arr = np.array(np.arange(10_000))
     s = pd.Series(arr)
-    s_downsampled = MinMaxDownsampler.downsample(s, 100)
+    s_downsampled = MinMaxDownsampler().downsample(s, 100)
     assert s_downsampled.values[0] == 0
     assert s_downsampled.values[-1] == len(arr) - 1
 
@@ -42,7 +42,7 @@ def test_lttb_downsampler():
     """Test LTTB downsampler."""
     arr = np.array(np.arange(10_000))
     s = pd.Series(arr)
-    s_downsampled = LTTBDownsampler.downsample(s, 100)
+    s_downsampled = LTTBDownsampler().downsample(s, 100)
     assert s_downsampled.values[0] == 0
     assert s_downsampled.values[-1] == len(arr) - 1
 
@@ -51,34 +51,34 @@ def test_minmaxlttb_downsampler():
     """Test MinMaxLTTB downsampler."""
     arr = np.array(np.arange(10_000))
     s = pd.Series(arr)
-    s_downsampled = MinMaxLTTBDownsampler.downsample(s, 100, 30)
+    s_downsampled = MinMaxLTTBDownsampler().downsample(s, 100, 30)
     assert s_downsampled.values[0] == 0
     assert s_downsampled.values[-1] == len(arr) - 1
 
 
-def test_mean_downsampler():
-    """Test Mean downsampler."""
-    arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = MeanDownsampler.downsample(s, 100)
-    assert s_downsampled.values[0] == 49.5
-    assert s_downsampled.values[-1] == 9_949.5
+# def test_mean_downsampler():
+#     """Test Mean downsampler."""
+#     arr = np.array(np.arange(10_000))
+#     s = pd.Series(arr)
+#     s_downsampled = MeanDownsampler().downsample(s, 100)
+#     assert s_downsampled.values[0] == 49.5
+#     assert s_downsampled.values[-1] == 9_949.5
 
 
-def test_median_downsampler():
-    """Test Median downsampler."""
-    arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = MedianDownsampler.downsample(s, 100)
-    assert s_downsampled.values[0] == 49.5
-    assert s_downsampled.values[-1] == 9_949.5
+# def test_median_downsampler():
+#     """Test Median downsampler."""
+#     arr = np.array(np.arange(10_000))
+#     s = pd.Series(arr)
+#     s_downsampled = MedianDownsampler().downsample(s, 100)
+#     assert s_downsampled.values[0] == 49.5
+#     assert s_downsampled.values[-1] == 9_949.5
 
 
 def test_everynth_downsampler():
     """Test EveryNth downsampler."""
     arr = np.array(np.arange(10_000))
     s = pd.Series(arr)
-    s_downsampled = EveryNthDownsampler.downsample(s, 100)
+    s_downsampled = EveryNthDownsampler().downsample(s, 100)
     assert s_downsampled.values[0] == 0
     assert s_downsampled.values[-1] == 9_900
 
@@ -86,10 +86,10 @@ def test_everynth_downsampler():
 ## Parallel downsampling
 
 rust_downsamplers = [
-    MinMaxDownsampler,
-    M4Downsampler,
-    LTTBDownsampler,
-    MinMaxLTTBDownsampler,
+    MinMaxDownsampler(),
+    M4Downsampler(),
+    LTTBDownsampler(),
+    MinMaxLTTBDownsampler(),
 ]
 
 

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -1,5 +1,5 @@
+import pytest
 import numpy as np
-import pandas as pd
 
 from tsdownsample import (
     EveryNthDownsampler,
@@ -23,37 +23,33 @@ from tsdownsample import (
 def test_m4_downsampler():
     """Test M4 downsampler."""
     arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = M4Downsampler().downsample(s, 100)
-    assert s_downsampled.values[0] == 0
-    assert s_downsampled.values[-1] == len(arr) - 1
+    s_downsampled = M4Downsampler().downsample(arr, n_out=100)
+    assert s_downsampled[0] == 0
+    assert s_downsampled[-1] == len(arr) - 1
 
 
 def test_minmax_downsampler():
     """Test MinMax downsampler."""
     arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = MinMaxDownsampler().downsample(s, 100)
-    assert s_downsampled.values[0] == 0
-    assert s_downsampled.values[-1] == len(arr) - 1
+    s_downsampled = MinMaxDownsampler().downsample(arr, n_out=100)
+    assert s_downsampled[0] == 0
+    assert s_downsampled[-1] == len(arr) - 1
 
 
 def test_lttb_downsampler():
     """Test LTTB downsampler."""
     arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = LTTBDownsampler().downsample(s, 100)
-    assert s_downsampled.values[0] == 0
-    assert s_downsampled.values[-1] == len(arr) - 1
+    s_downsampled = LTTBDownsampler().downsample(arr, n_out=100)
+    assert s_downsampled[0] == 0
+    assert s_downsampled[-1] == len(arr) - 1
 
 
 def test_minmaxlttb_downsampler():
     """Test MinMaxLTTB downsampler."""
     arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = MinMaxLTTBDownsampler().downsample(s, 100, 30)
-    assert s_downsampled.values[0] == 0
-    assert s_downsampled.values[-1] == len(arr) - 1
+    s_downsampled = MinMaxLTTBDownsampler().downsample(arr, n_out=100)
+    assert s_downsampled[0] == 0
+    assert s_downsampled[-1] == len(arr) - 1
 
 
 # def test_mean_downsampler():
@@ -77,10 +73,9 @@ def test_minmaxlttb_downsampler():
 def test_everynth_downsampler():
     """Test EveryNth downsampler."""
     arr = np.array(np.arange(10_000))
-    s = pd.Series(arr)
-    s_downsampled = EveryNthDownsampler().downsample(s, 100)
-    assert s_downsampled.values[0] == 0
-    assert s_downsampled.values[-1] == 9_900
+    s_downsampled = EveryNthDownsampler().downsample(arr, n_out=100)
+    assert s_downsampled[0] == 0
+    assert s_downsampled[-1] == 9_900
 
 
 ## Parallel downsampling
@@ -96,14 +91,21 @@ rust_downsamplers = [
 def test_parallel_downsampling():
     """Test parallel downsampling."""
     arr = np.random.randn(10_000).astype(np.float32)
-    s = pd.Series(arr)
     for downsampler in rust_downsamplers:
-        args = []
-        if downsampler == MinMaxLTTBDownsampler:
-            args = [30]
-        s_downsampled = downsampler.downsample(s, 100, *args, parallel=False)
-        s_downsampled_p = downsampler.downsample(s, 100, *args, parallel=True)
-        assert s_downsampled.equals(s_downsampled_p)
+        s_downsampled = downsampler.downsample(arr, n_out=100, parallel=False)
+        s_downsampled_p = downsampler.downsample(arr, n_out=100, parallel=True)
+        assert np.all(s_downsampled == s_downsampled_p)
+
+## Using x
+
+def test_downsampling_with_x():
+    """Test downsampling with x."""
+    arr = np.random.randn(10_000).astype(np.float32)
+    idx = np.arange(len(arr))
+    for downsampler in rust_downsamplers:
+        s_downsampled = downsampler.downsample(arr, n_out=100)
+        s_downsampled_x = downsampler.downsample(idx, arr, n_out=100)
+        assert np.all(s_downsampled == s_downsampled_x)
 
 
 ## Data types
@@ -123,8 +125,58 @@ supported_dtypes = [
 
 def test_downsampling_different_dtypes():
     """Test downsampling with different data types."""
-    arr = np.random.randn(10_000)
+    arr_orig = np.random.randint(0, 100, size=10_000)
+    res = []
     for dtype in supported_dtypes:
-        s = pd.Series(arr.astype(dtype))
-        s_downsampled = MinMaxDownsampler.downsample(s, 100)
-        assert s_downsampled.dtype == dtype
+        arr = arr_orig.astype(dtype)
+        s_downsampled = MinMaxDownsampler().downsample(arr, n_out=100)
+        res += [s_downsampled]
+    for i in range(1, len(res)):
+        assert np.all(res[0] == res[i])
+
+def test_downsampling_different_dtypes_with_x():
+    """Test downsampling with different data types."""
+    arr_orig = np.random.randint(0, 100, size=10_000)
+    idx_orig = np.arange(len(arr_orig))
+    for dtype_x in supported_dtypes:
+        res = []
+        idx = idx_orig.astype(dtype_x)
+        for dtype_y in supported_dtypes:
+            arr = arr_orig.astype(dtype_y)
+            s_downsampled = MinMaxLTTBDownsampler().downsample(idx, arr, n_out=100)
+            res += [s_downsampled]
+        for i in range(1, len(res)):
+            assert np.all(res[0] == res[i])
+
+### Unsupported dtype
+
+def test_error_unsupported_dtype():
+    """Test unsupported dtype."""
+    arr = np.random.randint(0, 100, size=10_000)
+    arr = arr.astype(np.bool)
+    with pytest.raises(ValueError):
+        MinMaxDownsampler().downsample(arr, n_out=100)
+
+def test_error_invalid_args():
+    """Test invalid arguments."""
+    arr = np.random.randint(0, 100, size=10_000)
+    # No args
+    with pytest.raises(ValueError) as e_msg:
+        MinMaxDownsampler().downsample(n_out=100, parallel=True)
+    assert "takes 1 or 2 positional arguments" in str(e_msg.value)
+    # Too many args
+    with pytest.raises(ValueError) as e_msg:
+        MinMaxDownsampler().downsample(arr, arr, arr, n_out=100, parallel=True)
+    assert "takes 1 or 2 positional arguments" in str(e_msg.value)
+    # Invalid y
+    with pytest.raises(ValueError) as e_msg:
+        MinMaxDownsampler().downsample(arr.reshape(5, 2_000), n_out=100, parallel=True)
+    assert "y must be 1D" in str(e_msg.value)
+    # Invalid x
+    with pytest.raises(ValueError) as e_msg:
+        MinMaxDownsampler().downsample(arr.reshape(5, 2_000), arr, n_out=100, parallel=True)
+    assert "x must be 1D" in str(e_msg.value)
+    # Invalid x and y (different length)
+    with pytest.raises(ValueError) as e_msg:
+        MinMaxDownsampler().downsample(arr, arr[:-1], n_out=100, parallel=True)
+    assert "x and y must have the same length" in str(e_msg.value)

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -50,24 +50,6 @@ def test_minmaxlttb_downsampler():
     assert s_downsampled[-1] == len(arr) - 1
 
 
-# def test_mean_downsampler():
-#     """Test Mean downsampler."""
-#     arr = np.array(np.arange(10_000))
-#     s = pd.Series(arr)
-#     s_downsampled = MeanDownsampler().downsample(s, 100)
-#     assert s_downsampled.values[0] == 49.5
-#     assert s_downsampled.values[-1] == 9_949.5
-
-
-# def test_median_downsampler():
-#     """Test Median downsampler."""
-#     arr = np.array(np.arange(10_000))
-#     s = pd.Series(arr)
-#     s_downsampled = MedianDownsampler().downsample(s, 100)
-#     assert s_downsampled.values[0] == 49.5
-#     assert s_downsampled.values[-1] == 9_949.5
-
-
 def test_everynth_downsampler():
     """Test EveryNth downsampler."""
     arr = np.array(np.arange(10_000))
@@ -137,11 +119,14 @@ def test_downsampling_different_dtypes():
         assert np.all(res[0] == res[i])
 
 
+supported_dtypes_x = supported_dtypes + [np.datetime64]
+
+
 def test_downsampling_different_dtypes_with_x():
     """Test downsampling with different data types."""
     arr_orig = np.random.randint(0, 100, size=10_000)
     idx_orig = np.arange(len(arr_orig))
-    for dtype_x in supported_dtypes:
+    for dtype_x in supported_dtypes_x:
         res = []
         idx = idx_orig.astype(dtype_x)
         for dtype_y in supported_dtypes:

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -97,12 +97,14 @@ def test_parallel_downsampling():
 
 ## Using x
 
+all_downsamplers = rust_downsamplers + [EveryNthDownsampler()]
+
 
 def test_downsampling_with_x():
     """Test downsampling with x."""
     arr = np.random.randn(10_000).astype(np.float32)
     idx = np.arange(len(arr))
-    for downsampler in rust_downsamplers:
+    for downsampler in all_downsamplers:
         s_downsampled = downsampler.downsample(arr, n_out=100)
         s_downsampled_x = downsampler.downsample(idx, arr, n_out=100)
         assert np.all(s_downsampled == s_downsampled_x)

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from test_config import supported_dtypes_x, supported_dtypes_y
 
 from tsdownsample import (  # MeanDownsampler,; MedianDownsampler,
     EveryNthDownsampler,
@@ -93,21 +94,6 @@ def test_downsampling_with_x():
 
 
 ## Data types
-
-core_supported_dtypes = [
-    np.float16,
-    np.float32,
-    np.float64,
-    np.int16,
-    np.int32,
-    np.int64,
-    np.uint16,
-    np.uint32,
-    np.uint64,
-]
-
-supported_dtypes_x = core_supported_dtypes + [np.datetime64]
-supported_dtypes_y = core_supported_dtypes + [np.int8, np.uint8, np.bool8]
 
 
 def test_downsampling_different_dtypes():

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -94,7 +94,7 @@ def test_downsampling_with_x():
 
 ## Data types
 
-supported_dtypes = [
+core_supported_dtypes = [
     np.float16,
     np.float32,
     np.float64,
@@ -106,20 +106,21 @@ supported_dtypes = [
     np.uint64,
 ]
 
+supported_dtypes_x = core_supported_dtypes + [np.datetime64]
+supported_dtypes_y = core_supported_dtypes + [np.int8, np.uint8, np.bool8]
+
 
 def test_downsampling_different_dtypes():
     """Test downsampling with different data types."""
     arr_orig = np.random.randint(0, 100, size=10_000)
     res = []
-    for dtype in supported_dtypes:
+    for dtype in supported_dtypes_y:
         arr = arr_orig.astype(dtype)
         s_downsampled = MinMaxDownsampler().downsample(arr, n_out=100)
-        res += [s_downsampled]
+        if dtype is not np.bool8:
+            res += [s_downsampled]
     for i in range(1, len(res)):
         assert np.all(res[0] == res[i])
-
-
-supported_dtypes_x = supported_dtypes + [np.datetime64]
 
 
 def test_downsampling_different_dtypes_with_x():
@@ -129,10 +130,11 @@ def test_downsampling_different_dtypes_with_x():
     for dtype_x in supported_dtypes_x:
         res = []
         idx = idx_orig.astype(dtype_x)
-        for dtype_y in supported_dtypes:
+        for dtype_y in supported_dtypes_y:
             arr = arr_orig.astype(dtype_y)
             s_downsampled = MinMaxLTTBDownsampler().downsample(idx, arr, n_out=100)
-            res += [s_downsampled]
+            if dtype_y is not np.bool8:
+                res += [s_downsampled]
         for i in range(1, len(res)):
             assert np.all(res[0] == res[i])
 
@@ -143,7 +145,7 @@ def test_downsampling_different_dtypes_with_x():
 def test_error_unsupported_dtype():
     """Test unsupported dtype."""
     arr = np.random.randint(0, 100, size=10_000)
-    arr = arr.astype(np.bool)
+    arr = arr.astype("object")
     with pytest.raises(ValueError):
         MinMaxDownsampler().downsample(arr, n_out=100)
 

--- a/tsdownsample/__init__.py
+++ b/tsdownsample/__init__.py
@@ -1,4 +1,20 @@
+"""tsdownsample: high performance downsampling of time series data for visualization."""
+
+from .downsamplers import (
+    EveryNthDownsampler,
+    LTTBDownsampler,
+    M4Downsampler,
+    MinMaxDownsampler,
+    MinMaxLTTBDownsampler,
+)
+
 __version__ = "0.1.0a5"
 __author__ = "Jeroen Van Der Donckt"
 
-from .downsamplers import *
+__all__ = [
+    "EveryNthDownsampler",
+    "MinMaxDownsampler",
+    "M4Downsampler",
+    "LTTBDownsampler",
+    "MinMaxLTTBDownsampler",
+]

--- a/tsdownsample/__init__.py
+++ b/tsdownsample/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0a4"
+__version__ = "0.1.0a5"
 __author__ = "Jeroen Van Der Donckt"
 
 from .downsamplers import *

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -64,7 +64,7 @@ class MinMaxLTTBDownsampler(AbstractRustDownsampler):
         super().__init__("MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes)
 
     def downsample(
-        self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False
+        self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False, **_
     ):
         assert minmax_ratio > 0, "minmax_ratio must be greater than 0"
         return super().downsample(
@@ -81,7 +81,7 @@ class EveryNthDownsampler(AbstractDownsampler):
         super().__init__("EveryNth")
 
     def _downsample(
-        self, x: Union[np.ndarray, None], y: np.ndarray, n_out: int,  **kwargs
+        self, x: Union[np.ndarray, None], y: np.ndarray, n_out: int, **_
     ) -> np.ndarray:
         if x is not None:
             warnings.warn(

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -1,13 +1,12 @@
 import warnings
-import numpy as np
-
 from typing import Union
-from .downsampling_interface import AbstractDownsampler
+
+import numpy as np
 
 # ------------------ Rust Downsamplers ------------------
 from tsdownsample._rust import _tsdownsample_rs  # type: ignore[attr-defined]
 
-from .downsampling_interface import AbstractRustDownsampler
+from .downsampling_interface import AbstractDownsampler, AbstractRustDownsampler
 
 rust_dtypes = [
     "float16",
@@ -28,64 +27,68 @@ rust_dtypes = [
 #     "MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes
 # )
 
-class MinMaxDownsampler(AbstractRustDownsampler):
 
+class MinMaxDownsampler(AbstractRustDownsampler):
     def __init__(self) -> None:
         super().__init__("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
             warnings.warn(
-                f"x is passed to downsample method of {self.name}, but is not taken "/
+                f"x is passed to downsample method of {self.name}, but is not taken "
                 f"into account by the current implementation of  {self.name} algorithm."
             )
-        return super()._downsample(x, *args, **kwargs)
+        return super()._downsample(None, *args, **kwargs)
+
 
 class M4Downsampler(AbstractRustDownsampler):
-
     def __init__(self):
         super().__init__("M4", _tsdownsample_rs.m4, rust_dtypes)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
             warnings.warn(
-                f"x is passed to downsample method of {self.name}, but is not taken "/
-                f"into account by the current implementation of  {self.name} algorithm."
+                f"x is passed to downsample method of {self.name}, but is not taken "
+                / f"into account by the current implementation of  {self.name} algorithm."
             )
-        return super()._downsample(x, *args, **kwargs)
+        return super()._downsample(None, *args, **kwargs)
+
 
 class LTTBDownsampler(AbstractRustDownsampler):
-
     def __init__(self):
         super().__init__("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
 
-class MinMaxLTTBDownsampler(AbstractRustDownsampler):
 
+class MinMaxLTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
         super().__init__("MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes)
 
-    def downsample(self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False):
+    def downsample(
+        self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False
+    ):
         assert minmax_ratio > 0, "minmax_ratio must be greater than 0"
-        return super().downsample(*args, n_out=n_out, parallel=parallel, ratio=minmax_ratio)
+        return super().downsample(
+            *args, n_out=n_out, parallel=parallel, ratio=minmax_ratio
+        )
 
 
 # ------------------ EveryNth Downsampler ------------------
 import math
+
 
 class EveryNthDownsampler(AbstractDownsampler):
     def __init__(self) -> None:
         super().__init__("EveryNth")
 
     def _downsample(
-        self,
-        _: Union[np.ndarray, None],  # x is not used
-        y: np.ndarray,
-        n_out: int,
+        self, _: Union[np.ndarray, None], y: np.ndarray, n_out: int  # x is not used
     ) -> np.ndarray:
         step = max(1, math.ceil(len(y) / n_out))
         return np.arange(0, len(y), step)
 
+
 # ------------------ Function Downsampler ------------------
+
 
 class FuncDownsampler(AbstractDownsampler):
 

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -83,4 +83,3 @@ class EveryNthDownsampler(AbstractDownsampler):
             )
         step = max(1, math.ceil(len(y) / n_out))
         return np.arange(0, len(y), step)
-

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -2,7 +2,7 @@ import warnings
 import numpy as np
 
 from typing import Union
-from .downsampling_interface import DownsampleInterface
+from .downsampling_interface import AbstractDownsampler
 
 # ------------------ Rust Downsamplers ------------------
 from tsdownsample._rust import _tsdownsample_rs  # type: ignore[attr-defined]
@@ -39,7 +39,7 @@ class MinMaxDownsampler(AbstractRustDownsampler):
                 f"x is passed to downsample method of {self.name}, but is not taken "/
                 f"into account by the current implementation of  {self.name} algorithm."
             )
-        super()._downsample(x, *args, **kwargs)
+        return super()._downsample(x, *args, **kwargs)
 
 class M4Downsampler(AbstractRustDownsampler):
 
@@ -52,7 +52,7 @@ class M4Downsampler(AbstractRustDownsampler):
                 f"x is passed to downsample method of {self.name}, but is not taken "/
                 f"into account by the current implementation of  {self.name} algorithm."
             )
-        super()._downsample(x, *args, **kwargs)
+        return super()._downsample(x, *args, **kwargs)
 
 class LTTBDownsampler(AbstractRustDownsampler):
 
@@ -64,11 +64,15 @@ class MinMaxLTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
         super().__init__("MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes)
 
+    def downsample(self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False):
+        assert minmax_ratio > 0, "minmax_ratio must be greater than 0"
+        return super().downsample(*args, n_out=n_out, parallel=parallel, ratio=minmax_ratio)
+
 
 # ------------------ EveryNth Downsampler ------------------
 import math
 
-class EveryNthDownsampler(DownsampleInterface):
+class EveryNthDownsampler(AbstractDownsampler):
     def __init__(self) -> None:
         super().__init__("EveryNth")
 
@@ -83,6 +87,6 @@ class EveryNthDownsampler(DownsampleInterface):
 
 # ------------------ Function Downsampler ------------------
 
-class FuncDownsampler(DownsampleInterface):
+class FuncDownsampler(AbstractDownsampler):
 
     pass

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -23,38 +23,40 @@ rust_dtypes = [
 
 class MinMaxDownsampler(AbstractRustDownsampler):
     def __init__(self) -> None:
-        super().__init__("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
+        super().__init__(_tsdownsample_rs.minmax, rust_dtypes)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
+            name = self.__class__.__name__
             warnings.warn(
-                f"x is passed to downsample method of {self.name}, but is not taken "
-                f"into account by the current implementation of  {self.name} algorithm."
+                f"x is passed to downsample method of {name}, but is not taken "
+                "into account by the current implementation of the MinMax algorithm."
             )
         return super()._downsample(None, *args, **kwargs)
 
 
 class M4Downsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__("M4", _tsdownsample_rs.m4, rust_dtypes)
+        super().__init__(_tsdownsample_rs.m4, rust_dtypes)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
+            name = self.__class__.__name__
             warnings.warn(
-                f"x is passed to downsample method of {self.name}, but is not taken "
-                f"into account by the current implementation of  {self.name} algorithm."
+                f"x is passed to downsample method of {name}, but is not taken "
+                "into account by the current implementation of the M4 algorithm."
             )
         return super()._downsample(None, *args, **kwargs)
 
 
 class LTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
+        super().__init__(_tsdownsample_rs.lttb, rust_dtypes)
 
 
 class MinMaxLTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__("MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes)
+        super().__init__(_tsdownsample_rs.minmaxlttb, rust_dtypes)
 
     def downsample(
         self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False, **_
@@ -70,16 +72,14 @@ import math
 
 
 class EveryNthDownsampler(AbstractDownsampler):
-    def __init__(self) -> None:
-        super().__init__("EveryNth")
-
     def _downsample(
         self, x: Union[np.ndarray, None], y: np.ndarray, n_out: int, **_
     ) -> np.ndarray:
         if x is not None:
+            name = self.__class__.__name__
             warnings.warn(
-                f"x is passed to downsample method of {self.name}, but is not taken "
-                f"into account by the current implementation of  {self.name} algorithm."
+                f"x is passed to downsample method of {name}, but is not taken "
+                "into account by the current implementation of the EveryNth algorithm."
             )
         step = max(1, math.ceil(len(y) / n_out))
         return np.arange(0, len(y), step)

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -1,7 +1,13 @@
+import warnings
+import numpy as np
+
+from typing import Union
+from .downsampling_interface import DownsampleInterface
+
 # ------------------ Rust Downsamplers ------------------
 from tsdownsample._rust import _tsdownsample_rs  # type: ignore[attr-defined]
 
-from .downsampling_interface import RustDownsampler
+from .downsampling_interface import AbstractRustDownsampler
 
 rust_dtypes = [
     "float16",
@@ -15,26 +21,68 @@ rust_dtypes = [
     "int64",
 ]
 
-MinMaxDownsampler = RustDownsampler("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
-M4Downsampler = RustDownsampler("M4", _tsdownsample_rs.m4, rust_dtypes)
-LTTBDownsampler = RustDownsampler("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
-MinMaxLTTBDownsampler = RustDownsampler(
-    "MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes
-)
+# MinMaxDownsampler = RustDownsampler("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
+# M4Downsampler = RustDownsampler("M4", _tsdownsample_rs.m4, rust_dtypes)
+# LTTBDownsampler = RustDownsampler("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
+# MinMaxLTTBDownsampler = RustDownsampler(
+#     "MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes
+# )
+
+class MinMaxDownsampler(AbstractRustDownsampler):
+
+    def __init__(self) -> None:
+        super().__init__("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
+
+    def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
+        if x is not None:
+            warnings.warn(
+                f"x is passed to downsample method of {self.name}, but is not taken "/
+                f"into account by the current implementation of  {self.name} algorithm."
+            )
+        super()._downsample(x, *args, **kwargs)
+
+class M4Downsampler(AbstractRustDownsampler):
+
+    def __init__(self):
+        super().__init__("M4", _tsdownsample_rs.m4, rust_dtypes)
+
+    def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
+        if x is not None:
+            warnings.warn(
+                f"x is passed to downsample method of {self.name}, but is not taken "/
+                f"into account by the current implementation of  {self.name} algorithm."
+            )
+        super()._downsample(x, *args, **kwargs)
+
+class LTTBDownsampler(AbstractRustDownsampler):
+
+    def __init__(self):
+        super().__init__("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
+
+class MinMaxLTTBDownsampler(AbstractRustDownsampler):
+
+    def __init__(self):
+        super().__init__("MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes)
+
 
 # ------------------ EveryNth Downsampler ------------------
 import math
-import pandas as pd
 
-from .downsampling_interface import DownsampleInterface
-
-
-class _EveryNthDownsampler(DownsampleInterface):
+class EveryNthDownsampler(DownsampleInterface):
     def __init__(self) -> None:
         super().__init__("EveryNth")
 
     def _downsample(
-        
+        self,
+        _: Union[np.ndarray, None],  # x is not used
+        y: np.ndarray,
+        n_out: int,
+    ) -> np.ndarray:
+        step = max(1, math.ceil(len(y) / n_out))
+        return np.arange(0, len(y), step)
 
+# ------------------ Function Downsampler ------------------
 
-EveryNthDownsampler = _EveryNthDownsampler()
+class FuncDownsampler(DownsampleInterface):
+
+    pass

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -81,8 +81,13 @@ class EveryNthDownsampler(AbstractDownsampler):
         super().__init__("EveryNth")
 
     def _downsample(
-        self, _: Union[np.ndarray, None], y: np.ndarray, n_out: int  # x is not used
+        self, x: Union[np.ndarray, None], y: np.ndarray, n_out: int,  **kwargs
     ) -> np.ndarray:
+        if x is not None:
+            warnings.warn(
+                f"x is passed to downsample method of {self.name}, but is not taken "
+                f"into account by the current implementation of  {self.name} algorithm."
+            )
         step = max(1, math.ceil(len(y) / n_out))
         return np.arange(0, len(y), step)
 

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -1,26 +1,29 @@
 # ------------------ Rust Downsamplers ------------------
 from tsdownsample._rust import _tsdownsample_rs  # type: ignore[attr-defined]
 
-from .downsampling_interface import RustDownsamplingInterface
+from .downsampling_interface import RustDownsampler
 
-MinMaxDownsampler = RustDownsamplingInterface("MinMax", _tsdownsample_rs.minmax)
-M4Downsampler = RustDownsamplingInterface("M4", _tsdownsample_rs.m4)
-LTTBDownsampler = RustDownsamplingInterface("LTTB", _tsdownsample_rs.lttb)
-MinMaxLTTBDownsampler = RustDownsamplingInterface(
-    "MinMaxLTTB", _tsdownsample_rs.minmaxlttb
+rust_dtypes = [
+    "float16",
+    "float32",
+    "float64",
+    "uint16",
+    "uint32",
+    "uint64",
+    "int16",
+    "int32",
+    "int64",
+]
+
+MinMaxDownsampler = RustDownsampler("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
+M4Downsampler = RustDownsampler("M4", _tsdownsample_rs.m4, rust_dtypes)
+LTTBDownsampler = RustDownsampler("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
+MinMaxLTTBDownsampler = RustDownsampler(
+    "MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes
 )
-
-# ------------------ Function Downsamplers ------------------
-import numpy as np
-
-from .downsampling_interface import FuncDownsamplingInterface
-
-MeanDownsampler = FuncDownsamplingInterface("Mean", np.mean)
-MedianDownsampler = FuncDownsamplingInterface("Median", np.median)
 
 # ------------------ EveryNth Downsampler ------------------
 import math
-
 import pandas as pd
 
 from .downsampling_interface import DownsampleInterface
@@ -30,10 +33,8 @@ class _EveryNthDownsampler(DownsampleInterface):
     def __init__(self) -> None:
         super().__init__("EveryNth")
 
-    def downsample(
-        self, s: pd.Series, n_out: int, *args, parallel: bool = False
-    ) -> pd.Series:
-        return s[:: max(1, math.ceil(len(s) / n_out))]
+    def _downsample(
+        
 
 
 EveryNthDownsampler = _EveryNthDownsampler()

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -20,13 +20,6 @@ rust_dtypes = [
     "int64",
 ]
 
-# MinMaxDownsampler = RustDownsampler("MinMax", _tsdownsample_rs.minmax, rust_dtypes)
-# M4Downsampler = RustDownsampler("M4", _tsdownsample_rs.m4, rust_dtypes)
-# LTTBDownsampler = RustDownsampler("LTTB", _tsdownsample_rs.lttb, rust_dtypes)
-# MinMaxLTTBDownsampler = RustDownsampler(
-#     "MinMaxLTTB", _tsdownsample_rs.minmaxlttb, rust_dtypes
-# )
-
 
 class MinMaxDownsampler(AbstractRustDownsampler):
     def __init__(self) -> None:

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from typing import Union
 
@@ -68,7 +69,6 @@ class MinMaxLTTBDownsampler(AbstractRustDownsampler):
 
 
 # ------------------ EveryNth Downsampler ------------------
-import math
 
 
 class EveryNthDownsampler(AbstractDownsampler):
@@ -84,10 +84,3 @@ class EveryNthDownsampler(AbstractDownsampler):
         step = max(1, math.ceil(len(y) / n_out))
         return np.arange(0, len(y), step)
 
-
-# ------------------ Function Downsampler ------------------
-
-
-class FuncDownsampler(AbstractDownsampler):
-
-    pass

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -49,7 +49,7 @@ class M4Downsampler(AbstractRustDownsampler):
         if x is not None:
             warnings.warn(
                 f"x is passed to downsample method of {self.name}, but is not taken "
-                / f"into account by the current implementation of  {self.name} algorithm."
+                f"into account by the current implementation of  {self.name} algorithm."
             )
         return super()._downsample(None, *args, **kwargs)
 

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -9,22 +9,10 @@ from tsdownsample._rust import _tsdownsample_rs  # type: ignore[attr-defined]
 
 from .downsampling_interface import AbstractDownsampler, AbstractRustDownsampler
 
-rust_dtypes = [
-    "float16",
-    "float32",
-    "float64",
-    "uint16",
-    "uint32",
-    "uint64",
-    "int16",
-    "int32",
-    "int64",
-]
-
 
 class MinMaxDownsampler(AbstractRustDownsampler):
     def __init__(self) -> None:
-        super().__init__(_tsdownsample_rs.minmax, rust_dtypes)
+        super().__init__(_tsdownsample_rs.minmax)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
@@ -38,7 +26,7 @@ class MinMaxDownsampler(AbstractRustDownsampler):
 
 class M4Downsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__(_tsdownsample_rs.m4, rust_dtypes)
+        super().__init__(_tsdownsample_rs.m4)
 
     def _downsample(self, x: Union[np.ndarray, None], *args, **kwargs):
         if x is not None:
@@ -52,12 +40,12 @@ class M4Downsampler(AbstractRustDownsampler):
 
 class LTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__(_tsdownsample_rs.lttb, rust_dtypes)
+        super().__init__(_tsdownsample_rs.lttb)
 
 
 class MinMaxLTTBDownsampler(AbstractRustDownsampler):
     def __init__(self):
-        super().__init__(_tsdownsample_rs.minmaxlttb, rust_dtypes)
+        super().__init__(_tsdownsample_rs.minmaxlttb)
 
     def downsample(
         self, *args, n_out: int, minmax_ratio: int = 30, parallel: bool = False, **_

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -244,7 +244,7 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
             if self.mod_multi_core is None:
                 warnings.warn(
                     f"No parallel implementation available for {self.name}. "
-                    / "Falling back to single-core implementation."
+                    "Falling back to single-core implementation."
                 )
         if x is None:
             downsample_f = _switch_mod_with_y(y.dtype, mod)

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -2,11 +2,11 @@
 
 __author__ = "Jeroen Van Der Donckt"
 
-import warnings
 import re
+import warnings
 from abc import ABC, abstractmethod
-from typing import Callable, List, Union, Tuple
 from types import ModuleType
+from typing import Callable, List, Tuple, Union
 
 import numpy as np
 
@@ -33,7 +33,9 @@ class AbstractDownsampler(ABC):
         )
 
     @staticmethod
-    def _check_valid_downsample_args(*args) -> Tuple[Union[np.ndarray, None], np.ndarray]:
+    def _check_valid_downsample_args(
+        *args,
+    ) -> Tuple[Union[np.ndarray, None], np.ndarray]:
         if len(args) == 2:
             x, y = args
         elif len(args) == 1:
@@ -71,12 +73,7 @@ class AbstractDownsampler(ABC):
         """
         raise NotImplementedError
 
-    def downsample(
-        self,
-        *args, # x and y are optional
-        n_out: int,
-        **kwargs,
-    ):
+    def downsample(self, *args, n_out: int, **kwargs):  # x and y are optional
         """Downsample y (and x).
 
         Call signatures::
@@ -94,7 +91,7 @@ class AbstractDownsampler(ABC):
             The number of points to keep.
         **kwargs
             Additional keyword arguments are passed to the downsampler.
-        
+
         Returns
         -------
         np.ndarray
@@ -232,7 +229,7 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
         elif hasattr(self.rust_mod, "scalar_parallel"):
             # use scalar implementation if available (when no SIMD available)
             self.mod_multi_core = self.rust_mod.scalar_parallel
-        
+
     def _downsample(
         self,
         x: Union[np.ndarray, None],
@@ -246,8 +243,8 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
         if parallel:
             if self.mod_multi_core is None:
                 warnings.warn(
-                    f"No parallel implementation available for {self.name}. "/
-                    "Falling back to single-core implementation."
+                    f"No parallel implementation available for {self.name}. "
+                    / "Falling back to single-core implementation."
                 )
         if x is None:
             downsample_f = _switch_mod_with_y(y.dtype, mod)
@@ -257,7 +254,7 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
 
     def downsample(
         self,
-        *args, # x and y are optional
+        *args,  # x and y are optional
         n_out: int,
         parallel: bool = False,
         **kwargs,

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -15,7 +15,6 @@ class AbstractDownsampler(ABC):
     """AbstractDownsampler interface-class, subclassed by concrete downsamplers."""
 
     def __init__(self, name: str, dtype_regex_list: List[str] = None):
-        """Initialize the downsampler with a list of regexes to match the data-types to downsample."""
         self.name = name
         self.dtype_regex_list = dtype_regex_list
 
@@ -211,7 +210,6 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
     def __init__(
         self, name: str, resampling_mod: ModuleType, dtype_regex_list: List[str]
     ):
-        """Initialize the downsampler with a list of regexes to match the data-types to downsample."""
         super().__init__(name, dtype_regex_list)
         self.rust_mod = resampling_mod
 

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -14,11 +14,11 @@ import numpy as np
 class AbstractDownsampler(ABC):
     """AbstractDownsampler interface-class, subclassed by concrete downsamplers."""
 
-    def __init__(self, name: str, dtype_regex_list: List[str] = None):
+    def __init__(self, name: str, dtype_regex_list: Union[List[str], None] = None):
         self.name = name
         self.dtype_regex_list = dtype_regex_list
 
-    def _supports_dtype(self, arr: np.array):
+    def _supports_dtype(self, arr: np.ndarray):
         # base case
         if self.dtype_regex_list is None:
             return
@@ -58,9 +58,9 @@ class AbstractDownsampler(ABC):
     @abstractmethod
     def _downsample(
         self,
-        x: Union[np.ndarray, None] = None,
-        y: Union[np.ndarray, None] = None,
-        n_out: int = None,
+        x: Union[np.ndarray, None],
+        y: np.ndarray,
+        n_out: int,
         **kwargs,
     ) -> np.ndarray:
         """Downsample the data in x and y.
@@ -231,8 +231,8 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
     def _downsample(
         self,
         x: Union[np.ndarray, None],
-        y: Union[np.ndarray, None],
-        n_out: int = None,
+        y: np.ndarray,
+        n_out: int,
         parallel: bool = False,
         **kwargs,
     ) -> np.ndarray:

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -240,6 +240,8 @@ class AbstractRustDownsampler(AbstractDownsampler, ABC):
                     f"No parallel implementation available for {self.name}. "
                     "Falling back to single-core implementation."
                 )
+            else:
+                mod = self.mod_multi_core
         if x is None:
             downsample_f = _switch_mod_with_y(y.dtype, mod)
             return downsample_f(y, n_out, **kwargs)

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -57,11 +57,7 @@ class AbstractDownsampler(ABC):
 
     @abstractmethod
     def _downsample(
-        self,
-        x: Union[np.ndarray, None],
-        y: np.ndarray,
-        n_out: int,
-        **kwargs,
+        self, x: Union[np.ndarray, None], y: np.ndarray, n_out: int, **kwargs
     ) -> np.ndarray:
         """Downsample the data in x and y.
 

--- a/tsdownsample/downsampling_interface.py
+++ b/tsdownsample/downsampling_interface.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from types import ModuleType
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -14,7 +14,7 @@ import numpy as np
 class AbstractDownsampler(ABC):
     """AbstractDownsampler interface-class, subclassed by concrete downsamplers."""
 
-    def __init__(self, name: str, dtype_regex_list: Union[List[str], None] = None):
+    def __init__(self, name: str, dtype_regex_list: Optional[List[str]] = None):
         self.name = name
         self.dtype_regex_list = dtype_regex_list
 


### PR DESCRIPTION
In this PR we transfer from `pandas.Series` as representation for time series to a purely `np.ndarray` based representation
(`pandas.Series` its index can at this time not represent most numeric dtypes, e.g. int16)

The signature for the downsample methdod is changed to:
```
downsample([x], y, n_out, **kwargs)
```
Note the following:
- `x` is optional, allowing the same (memory) efficient runtime as with `pd.RangeIndex`
- `x` and `y` are both positional arguments (this is in line with how the matplotlib,pyplot.plot signature is)
- `n_out` is a mandatory keyword argument

Example:
```py
from tsdownsample import MinMaxLTTBDownsampler
import numpy as np

# Create a time series
y = np.random.randn(10_000_000)

# Downsample to 1000 points
s_ds = MinMaxLTTBDownsampler().downsample(y, n_out=1000)
```

---

Other aspects of this PR
- [x] support `x` and `y` `datetime64`: [view the array](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.view.html) as `np.int64`
- [x] support `x` and `y` `timedelta64`: [view the array](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.view.html) as `np.int64`
- [x] support `y` bool: [view the array](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.view.html) as `np.int8` (under the hood numpy represents a bool as 8 bits)
- [x] support `y` int8 & uint8
- [ ] ~~support categorical data~~ => out of scope for this PR, would mostly be some Python code converting it to an encoding (which is perhaps not the responsibility of this library...)  - also not really sure how numpy would represent categorical data

Major TODOs: 
- documentation :ledger:  => will leave this for another PR
- do not assume fixed sampling rate => will leave this for another PR