### PR TITLE
:zap: faster parallel searchsorted

### DIFF
--- a/downsample_rs/src/m4/generic.rs
+++ b/downsample_rs/src/m4/generic.rs
@@ -131,10 +131,50 @@ pub(crate) fn m4_generic_with_x<T: Copy>(
     sampled_indices
 }
 
+// #[inline(always)]
+// pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
+//     arr: ArrayView1<T>,
+//     bin_idx_iterator: impl IndexedParallelIterator<Item = (usize, usize)>,
+//     n_out: usize,
+//     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
+// ) -> Array1<usize> {
+//     // Assumes n_out is a multiple of 4
+//     if n_out >= arr.len() {
+//         return Array1::from((0..arr.len()).collect::<Vec<usize>>());
+//     }
+
+//     let sampled_indices = Arc::new(Mutex::new(Array1::<usize>::default(n_out)));
+
+//     // Iterate over the sample_index pointers and the array chunks
+//     bin_idx_iterator
+//         .enumerate()
+//         .for_each(|(i, (start_idx, end_idx))| {
+//             let (min_index, max_index) = f_argminmax(arr.slice(s![start_idx..end_idx]));
+
+//             sampled_indices.lock().unwrap()[4 * i] = start_idx;
+
+//             // Add the indexes in sorted order
+//             if min_index < max_index {
+//                 sampled_indices.lock().unwrap()[4 * i + 1] = min_index + start_idx;
+//                 sampled_indices.lock().unwrap()[4 * i + 2] = max_index + start_idx;
+//             } else {
+//                 sampled_indices.lock().unwrap()[4 * i + 1] = max_index + start_idx;
+//                 sampled_indices.lock().unwrap()[4 * i + 2] = min_index + start_idx;
+//             }
+//             sampled_indices.lock().unwrap()[4 * i + 3] = end_idx - 1;
+//         });
+
+//     // Remove the mutex and return the sampled indices
+//     Arc::try_unwrap(sampled_indices)
+//         .unwrap()
+//         .into_inner()
+//         .unwrap()
+// }
+
 #[inline(always)]
 pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
     arr: ArrayView1<T>,
-    bin_idx_iterator: impl IndexedParallelIterator<Item = (usize, usize)>,
+    bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = (usize, (usize, usize))>>,
     n_out: usize,
     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
 ) -> Array1<usize> {
@@ -143,30 +183,28 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
         return Array1::from((0..arr.len()).collect::<Vec<usize>>());
     }
 
-    let sampled_indices = Arc::new(Mutex::new(Array1::<usize>::default(n_out)));
+    Array1::from_vec(
+        bin_idx_iterator
+            .flat_map(|bin_idx_iterator| {
+                bin_idx_iterator
+                    .map(|(_, (start, end))| {
+                        let step = arr.slice(s![start..end]); // TODO: optimize this
+                        let (min_index, max_index) = f_argminmax(step);
 
-    // Iterate over the sample_index pointers and the array chunks
-    bin_idx_iterator
-        .enumerate()
-        .for_each(|(i, (start_idx, end_idx))| {
-            let (min_index, max_index) = f_argminmax(arr.slice(s![start_idx..end_idx]));
-
-            sampled_indices.lock().unwrap()[4 * i] = start_idx;
-
-            // Add the indexes in sorted order
-            if min_index < max_index {
-                sampled_indices.lock().unwrap()[4 * i + 1] = min_index + start_idx;
-                sampled_indices.lock().unwrap()[4 * i + 2] = max_index + start_idx;
-            } else {
-                sampled_indices.lock().unwrap()[4 * i + 1] = max_index + start_idx;
-                sampled_indices.lock().unwrap()[4 * i + 2] = min_index + start_idx;
-            }
-            sampled_indices.lock().unwrap()[4 * i + 3] = end_idx - 1;
-        });
-
-    // Remove the mutex and return the sampled indices
-    Arc::try_unwrap(sampled_indices)
-        .unwrap()
-        .into_inner()
-        .unwrap()
+                        // Add the indexes in sorted order
+                        let mut sampled_index = [start, 0, 0, end - 1];
+                        if min_index < max_index {
+                            sampled_index[1] = min_index + start;
+                            sampled_index[2] = max_index + start;
+                        } else {
+                            sampled_index[1] = max_index + start;
+                            sampled_index[2] = min_index + start;
+                        }
+                        sampled_index
+                    })
+                    .collect::<Vec<[usize; 4]>>()
+            })
+            .flatten()
+            .collect::<Vec<usize>>(),
+    )
 }

--- a/downsample_rs/src/minmax/generic.rs
+++ b/downsample_rs/src/minmax/generic.rs
@@ -3,7 +3,6 @@ use ndarray::{s, Array1, ArrayView1};
 
 use rayon::iter::IndexedParallelIterator;
 use rayon::prelude::*;
-use std::sync::{Arc, Mutex};
 
 // --------------------- WITHOUT X
 
@@ -120,140 +119,10 @@ pub(crate) fn min_max_generic_with_x<T: Copy>(
     sampled_indices
 }
 
-// #[inline(never)]
-// pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
-//     arr: ArrayView1<T>,
-//     bin_idx_iterator: impl IndexedParallelIterator<Item = (usize, usize)>,
-//     n_out: usize,
-//     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
-// ) -> Array1<usize> {
-//     // Assumes n_out is a multiple of 2
-//     if n_out >= arr.len() {
-//         return Array1::from((0..arr.len()).collect::<Vec<usize>>());
-//     }
-
-//     // let sampled_indices = bin_idx_iterator.enumerate().flat_map(|(i, (start, end))| {
-//     //     let step = arr.slice(s![start..end]);
-//     //     let (min_index, max_index) = f_argminmax(step);
-
-//     //     // Add the indexes in sorted order
-//     //     let mut sampled_index = [0, 0];
-//     //     if min_index < max_index {
-//     //         sampled_index[0] = min_index + start;
-//     //         sampled_index[1] = max_index + start;
-//     //         // (min_index + start, max_index + start)
-//     //     } else {
-//     //         sampled_index[0] = max_index + start;
-//     //         sampled_index[1] = min_index + start;
-//     //         // (max_index + start, min_index + start)
-//     //     }
-//     //     sampled_index
-//     // }).collect::<Vec<usize>>();
-//     // Array1::from(sampled_indices)
-
-//     // Create a mutex to store the sampled indices
-//     let sampled_indices = Arc::new(Mutex::new(Array1::<usize>::default(n_out)));
-
-//     // Iterate over the bins
-//     bin_idx_iterator.enumerate().for_each(|(i, (start, end))| {
-//         let (min_index, max_index) = f_argminmax(arr.slice(s![start..end]));
-
-//         // Add the indexes in sorted order
-//         if min_index < max_index {
-//             sampled_indices.lock().unwrap()[2 * i] = min_index + start;
-//             sampled_indices.lock().unwrap()[2 * i + 1] = max_index + start;
-//         } else {
-//             sampled_indices.lock().unwrap()[2 * i] = max_index + start;
-//             sampled_indices.lock().unwrap()[2 * i + 1] = min_index + start;
-//         }
-//     });
-
-//     // Remove the mutex and return the sampled indices
-//     Arc::try_unwrap(sampled_indices)
-//         .unwrap()
-//         .into_inner()
-//         .unwrap()
-// }
-
-// #[inline(always)]
-// pub(crate) fn min_max_generic_with_x_parallel_v1<T: Copy + Send + Sync>(
-//     arr: ArrayView1<T>,
-//     bin_idx_iterator: impl IndexedParallelIterator<Item = (usize, usize)>,
-//     n_out: usize,
-//     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
-// ) -> Array1<usize> {
-//     // Assumes n_out is a multiple of 2
-//     if n_out >= arr.len() {
-//         return Array1::from((0..arr.len()).collect::<Vec<usize>>());
-//     }
-
-//     Array1::from_vec(
-//         bin_idx_iterator
-//             .enumerate()
-//             .flat_map(|(i, (start, end))| {
-//                 let step = arr.slice(s![start..end]);
-//                 let (min_index, max_index) = f_argminmax(step);
-
-//                 // Add the indexes in sorted order
-//                 let mut sampled_index = [0, 0];
-//                 if min_index < max_index {
-//                     sampled_index[0] = min_index + start;
-//                     sampled_index[1] = max_index + start;
-//                     // (min_index + start, max_index + start)
-//                 } else {
-//                     sampled_index[0] = max_index + start;
-//                     sampled_index[1] = min_index + start;
-//                     // (max_index + start, min_index + start)
-//                 }
-//                 sampled_index
-//             })
-//             .collect::<Vec<usize>>(),
-//     )
-// }
-
-// #[inline(always)]
-// pub(crate) fn min_max_generic_with_x_parallel_v2<T: Copy + Send + Sync>(
-//     arr: ArrayView1<T>,
-//     bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = (usize, (usize, usize))>>,
-//     n_out: usize,
-//     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
-// ) -> Array1<usize> {
-//     // Assumes n_out is a multiple of 2
-//     if n_out >= arr.len() {
-//         return Array1::from((0..arr.len()).collect::<Vec<usize>>());
-//     }
-
-//     // Create a mutex to store the sampled indices
-//     let sampled_indices = Arc::new(Mutex::new(Array1::<usize>::default(n_out)));
-
-//     // Iterate over the bins
-//     bin_idx_iterator.for_each(|bin_idx_iterator| {
-//         bin_idx_iterator.for_each(|(bin_idx, (start, end))| {
-//             let (min_index, max_index) = f_argminmax(arr.slice(s![start..end]));
-
-//             // Add the indexes in sorted order
-//             if min_index < max_index {
-//                 sampled_indices.lock().unwrap()[2 * bin_idx] = min_index + start;
-//                 sampled_indices.lock().unwrap()[2 * bin_idx + 1] = max_index + start;
-//             } else {
-//                 sampled_indices.lock().unwrap()[2 * bin_idx] = max_index + start;
-//                 sampled_indices.lock().unwrap()[2 * bin_idx + 1] = min_index + start;
-//             }
-//         });
-//     });
-
-//     // Remove the mutex and return the sampled indices
-//     Arc::try_unwrap(sampled_indices)
-//         .unwrap()
-//         .into_inner()
-//         .unwrap()
-// }
-
-
 #[inline(always)]
 pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
     arr: ArrayView1<T>,
-    bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = (usize, (usize, usize))>>,
+    bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = (usize, usize)>>,
     n_out: usize,
     f_argminmax: fn(ArrayView1<T>) -> (usize, usize),
 ) -> Array1<usize> {
@@ -266,8 +135,10 @@ pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
         bin_idx_iterator
             .flat_map(|bin_idx_iterator| {
                 bin_idx_iterator
-                    .map(|(_, (start, end))| {  // TODO: Remove the bin_idx
-                        let step = arr.slice(s![start..end]); // TODO: optimize this
+                    .map(|(start, end)| {
+                        let step = unsafe {
+                            ArrayView1::from_shape_ptr(end - start, arr.as_ptr().add(start))
+                        };
                         let (min_index, max_index) = f_argminmax(step);
 
                         // Add the indexes in sorted order

--- a/downsample_rs/src/minmax/simd.rs
+++ b/downsample_rs/src/minmax/simd.rs
@@ -48,6 +48,58 @@ where
 
 // ----------- WITH X
 
+// use super::super::searchsorted::get_equidistant_bin_idx_iterator_parallel_v2;
+
+// pub fn min_max_simd_with_x_parallel<Tx, Ty>(
+//     x: ArrayView1<Tx>,
+//     arr: ArrayView1<Ty>,
+//     n_out: usize,
+// ) -> Array1<usize>
+// where
+//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
+//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
+//     Ty: Copy + PartialOrd + Send + Sync,
+// {
+//     assert_eq!(n_out % 2, 0);
+//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out / 2);
+//     min_max_generic_with_x_parallel(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
+// }
+
+// use super::generic::min_max_generic_with_x_parallel_v1;
+
+// pub fn min_max_simd_with_x_parallel_v1<Tx, Ty>(
+//     x: ArrayView1<Tx>,
+//     arr: ArrayView1<Ty>,
+//     n_out: usize,
+// ) -> Array1<usize>
+// where
+//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
+//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
+//     Ty: Copy + PartialOrd + Send + Sync,
+// {
+//     assert_eq!(n_out % 2, 0);
+//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out / 2);
+//     min_max_generic_with_x_parallel_v1(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
+// }
+
+// use super::generic::min_max_generic_with_x_parallel_v2;
+
+// pub fn min_max_simd_with_x_parallel_v2<Tx, Ty>(
+//     x: ArrayView1<Tx>,
+//     arr: ArrayView1<Ty>,
+//     n_out: usize,
+// ) -> Array1<usize>
+// where
+//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
+//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
+//     Ty: Copy + PartialOrd + Send + Sync,
+// {
+//     assert_eq!(n_out % 2, 0);
+//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel_v2(x, n_out / 2);
+//     min_max_generic_with_x_parallel_v2(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
+// }
+
+// use super::generic::min_max_generic_with_x_parallel_v3;
 pub fn min_max_simd_with_x_parallel<Tx, Ty>(
     x: ArrayView1<Tx>,
     arr: ArrayView1<Ty>,
@@ -58,7 +110,7 @@ where
     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
     Ty: Copy + PartialOrd + Send + Sync,
 {
-    assert_eq!(n_out % 2, 0);
+    assert_eq!(n_out % 2, 0); // TODO can be faster (check last bit)
     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out / 2);
     min_max_generic_with_x_parallel(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
 }

--- a/downsample_rs/src/minmax/simd.rs
+++ b/downsample_rs/src/minmax/simd.rs
@@ -48,58 +48,6 @@ where
 
 // ----------- WITH X
 
-// use super::super::searchsorted::get_equidistant_bin_idx_iterator_parallel_v2;
-
-// pub fn min_max_simd_with_x_parallel<Tx, Ty>(
-//     x: ArrayView1<Tx>,
-//     arr: ArrayView1<Ty>,
-//     n_out: usize,
-// ) -> Array1<usize>
-// where
-//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
-//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
-//     Ty: Copy + PartialOrd + Send + Sync,
-// {
-//     assert_eq!(n_out % 2, 0);
-//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out / 2);
-//     min_max_generic_with_x_parallel(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
-// }
-
-// use super::generic::min_max_generic_with_x_parallel_v1;
-
-// pub fn min_max_simd_with_x_parallel_v1<Tx, Ty>(
-//     x: ArrayView1<Tx>,
-//     arr: ArrayView1<Ty>,
-//     n_out: usize,
-// ) -> Array1<usize>
-// where
-//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
-//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
-//     Ty: Copy + PartialOrd + Send + Sync,
-// {
-//     assert_eq!(n_out % 2, 0);
-//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out / 2);
-//     min_max_generic_with_x_parallel_v1(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
-// }
-
-// use super::generic::min_max_generic_with_x_parallel_v2;
-
-// pub fn min_max_simd_with_x_parallel_v2<Tx, Ty>(
-//     x: ArrayView1<Tx>,
-//     arr: ArrayView1<Ty>,
-//     n_out: usize,
-// ) -> Array1<usize>
-// where
-//     for<'a> ArrayView1<'a, Ty>: ArgMinMax,
-//     Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
-//     Ty: Copy + PartialOrd + Send + Sync,
-// {
-//     assert_eq!(n_out % 2, 0);
-//     let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel_v2(x, n_out / 2);
-//     min_max_generic_with_x_parallel_v2(arr, bin_idx_iterator, n_out, |arr| arr.argminmax())
-// }
-
-// use super::generic::min_max_generic_with_x_parallel_v3;
 pub fn min_max_simd_with_x_parallel<Tx, Ty>(
     x: ArrayView1<Tx>,
     arr: ArrayView1<Ty>,

--- a/downsample_rs/src/searchsorted.rs
+++ b/downsample_rs/src/searchsorted.rs
@@ -77,15 +77,15 @@ where
     let mut value: f64 = arr[0].as_(); // Search value
     let mut idx: usize = 0; // Index of the search value
     (0..nb_bins).map(move |_| {
-        let start_idx = idx; // Start index of the bin (previous end index)
+        let start_idx: usize = idx; // Start index of the bin (previous end index)
         value += val_step;
-        let mid = idx + idx_step;
+        let mid: usize = idx + idx_step;
         let mid = if mid < arr.len() - 1 {
             mid
         } else {
             arr.len() - 2 // TODO: arr.len() - 1 gives error I thought...
         };
-        let search_value = T::from_f64(value).unwrap();
+        let search_value: T = T::from_f64(value).unwrap();
         // Implementation WITHOUT pre-guessing mid is slower!!
         // idx = binary_search(arr, search_value, idx, arr.len()-1);
         idx = binary_search_with_mid(arr, search_value, idx, arr.len() - 1, mid); // End index of the bin
@@ -129,18 +129,18 @@ where
     // -> for each thread perform the binary search sorted with moving left and
     // yield the indices (using the same idea as for the sequential version)
     (0..nb_threads).into_par_iter().map(move |i| {
-        // Search the start of the fist bin of the thread
-        let mut value = sequential_add_mul(arr0, val_step, i * nb_bins_per_thread); // Search value
+        // Search the start of the fist bin o(f the thread)
+        let mut value: f64 = sequential_add_mul(arr0, val_step, i * nb_bins_per_thread); // Search value
         let start_value: T = T::from_f64(value).unwrap();
-        let mut idx = binary_search(arr, start_value, 0, arr.len() - 1); // Index of the search value
+        let mut idx: usize = binary_search(arr, start_value, 0, arr.len() - 1); // Index of the search value
         let nb_bins_thread = if i == nb_threads - 1 {
             nb_bins_last_thread
         } else {
             nb_bins_per_thread
         };
-        // Perform sequential binary search for the end of the bins
+        // Perform sequential binary search for the end of the bins (of the thread)
         (0..nb_bins_thread).map(move |_| {
-            let start_idx = idx; // Start index of the bin (previous end index)
+            let start_idx: usize = idx; // Start index of the bin (previous end index)
             value += val_step;
             let search_value: T = T::from_f64(value).unwrap();
             idx = binary_search(arr, search_value, idx, arr.len() - 1); // End index of the bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "tsdownsample"
 description = "Extremely fast time series downsampling in Rust"
-version = "0.1.0a7"
+version = "0.1.0"
 requires-python = ">=3.7"
 dependencies = ["numpy"]
 authors = [{name = "Jeroen Van Der Donckt"}]

--- a/tsdownsample/__init__.py
+++ b/tsdownsample/__init__.py
@@ -8,7 +8,7 @@ from .downsamplers import (
     MinMaxLTTBDownsampler,
 )
 
-__version__ = "0.1.0a7"
+__version__ = "0.1.0"
 __author__ = "Jeroen Van Der Donckt"
 
 __all__ = [


### PR DESCRIPTION
This PR aims at optimizing the runtime of parallel downsampling with x, resolves #14 

To do so, the following optimizations are applied;
- :lock_with_ink_pen: no pre-allocation of output array (with mutex) -> (0.02s => 0.008s)
- :thread: `get_equidistant_bin_idx_iterator_parallel` now creates a nested iterator -> (0.008 -> 0.005s)
  - :exploding_head: the outer iterator yield `# threads` iterators
    => this allows to re-use the left index to perform a more efficient search sorted procedure (as is done in the sequential Iterator - see description in #14)