### PR TITLE
:arrow_up: change rust-numpy git dependency to release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ name = "tsdownsample._rust._tsdownsample_rs"
 
 [dependencies]
 downsample_rs = { path = "downsample_rs", features = ["half"]}
-pyo3 = { version = "0.17.2", features = ["extension-module"] }
-numpy = { git = "https://github.com/PyO3/rust-numpy", features = ["half"] }  # Replace this once new release is done
+pyo3 = { version = "0.18", features = ["extension-module"] }
+numpy = { version = "0.18", features = ["half"] }
 half = { version = "2.1", default-features = false }
 paste = { version = "1.0.9", default-features = false }
 


### PR DESCRIPTION
This should fix the failing `CI tsdownsample` (observed in #17)

The latest release of `rust-numpy` omits the need to use the GitHub repo as dependency & allows to update both the `pyo3` and `rust-numpy` dependencies to `v0.18`.

(Note we previously used the GitHub `rust-numpy` dependency as this already contained the updated `half` dependency - which was not yet available in the `v0.17.2`)