### PR TITLE
:hole: handle gaps in x

### DIFF
--- a/downsample_rs/Cargo.toml
+++ b/downsample_rs/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = { version = "0.2.15", default-features = false }
 rayon = { version = "1.6.0", default-features = false }
 
 [dev-dependencies]
-criterion = "0.3.0"
+criterion = "0.4.0"
 dev_utils = { path = "dev_utils" }
 
 [[bench]]

--- a/downsample_rs/src/m4/generic.rs
+++ b/downsample_rs/src/m4/generic.rs
@@ -155,22 +155,6 @@ pub(crate) fn m4_generic_with_x<T: Copy>(
             }
         }
     });
-    //     let step =
-    //         unsafe { ArrayView1::from_shape_ptr(end_idx - start_idx, arr_ptr.add(start_idx)) };
-    //     let (min_index, max_index) = f_argminmax(step);
-
-    //     sampled_indices[4 * i] = start_idx;
-
-    //     // Add the indexes in sorted order
-    //     if min_index < max_index {
-    //         sampled_indices[4 * i + 1] = min_index + start_idx;
-    //         sampled_indices[4 * i + 2] = max_index + start_idx;
-    //     } else {
-    //         sampled_indices[4 * i + 1] = max_index + start_idx;
-    //         sampled_indices[4 * i + 2] = min_index + start_idx;
-    //     }
-    //     sampled_indices[4 * i + 3] = end_idx - 1;
-    // });
 
     Array1::from_vec(sampled_indices)
 }
@@ -208,6 +192,7 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
                                     let (min_index, max_index) = f_argminmax(step);
 
                                     // Add the indexes in sorted order
+                                    // TODO: check above (is more "data" efficient)
                                     let mut sampled_index = vec![start, 0, 0, end - 1];
                                     if min_index < max_index {
                                         sampled_index[1] = min_index + start;
@@ -218,27 +203,11 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
                                     }
                                     sampled_index
                                 }
-                            }
+                            } // If the bin is empty, return empty Vec
                             None => {
                                 return vec![];
                             }
                         }
-
-                        // let step = unsafe {
-                        //     ArrayView1::from_shape_ptr(end - start, arr.as_ptr().add(start))
-                        // };
-                        // let (min_index, max_index) = f_argminmax(step);
-
-                        // // Add the indexes in sorted order
-                        // let mut sampled_index = [start, 0, 0, end - 1];
-                        // if min_index < max_index {
-                        //     sampled_index[1] = min_index + start;
-                        //     sampled_index[2] = max_index + start;
-                        // } else {
-                        //     sampled_index[1] = max_index + start;
-                        //     sampled_index[2] = min_index + start;
-                        // }
-                        // sampled_index
                     })
                     .collect::<Vec<Vec<usize>>>()
             })

--- a/downsample_rs/src/m4/generic.rs
+++ b/downsample_rs/src/m4/generic.rs
@@ -108,50 +108,43 @@ pub(crate) fn m4_generic_with_x<T: Copy>(
     let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out);
 
     bin_idx_iterator.for_each(|bin| {
-        match bin {
-            Some((start, end)) => {
-                if end <= start + 4 {
-                    // If the bin has <= 4 elements, just add them all
-                    for i in start..end {
-                        sampled_indices.push(i);
-                    }
-                } else {
-                    // If the bin has > 4 elements, add the first and last + argmin and argmax
-                    let step =
-                        unsafe { ArrayView1::from_shape_ptr(end - start, arr_ptr.add(start)) };
-                    let (min_index, max_index) = f_argminmax(step);
-
-                    sampled_indices.push(start);
-
-                    // Add the indexes in sorted order
-                    if min_index < max_index {
-                        // TODO: check the below (is more "data" efficient)
-                        // if min_index > start{
-                        //     sampled_indices.push(min_index + start);
-                        // }
-                        // if max_index < end - 1{
-                        //     sampled_indices.push(max_index + start);
-                        // }
-                        sampled_indices.push(min_index + start);
-                        sampled_indices.push(max_index + start);
-                    } else {
-                        // TODO: check the below (is more "data" efficient)
-                        // if max_index > start{
-                        //     sampled_indices.push(max_index + start);
-                        // }
-                        // if min_index < end - 1{
-                        //     sampled_indices.push(min_index + start);
-                        // }
-                        sampled_indices.push(max_index + start);
-                        sampled_indices.push(min_index + start);
-                    }
-
-                    sampled_indices.push(end - 1);
+        if let Some((start, end)) = bin {
+            if end <= start + 4 {
+                // If the bin has <= 4 elements, just add them all
+                for i in start..end {
+                    sampled_indices.push(i);
                 }
-            }
-            // If the bin is empty, do nothing
-            None => {
-                // Do nothing
+            } else {
+                // If the bin has > 4 elements, add the first and last + argmin and argmax
+                let step = unsafe { ArrayView1::from_shape_ptr(end - start, arr_ptr.add(start)) };
+                let (min_index, max_index) = f_argminmax(step);
+
+                sampled_indices.push(start);
+
+                // Add the indexes in sorted order
+                if min_index < max_index {
+                    // TODO: check the below (is more "data" efficient)
+                    // if min_index > start{
+                    //     sampled_indices.push(min_index + start);
+                    // }
+                    // if max_index < end - 1{
+                    //     sampled_indices.push(max_index + start);
+                    // }
+                    sampled_indices.push(min_index + start);
+                    sampled_indices.push(max_index + start);
+                } else {
+                    // TODO: check the below (is more "data" efficient)
+                    // if max_index > start{
+                    //     sampled_indices.push(max_index + start);
+                    // }
+                    // if min_index < end - 1{
+                    //     sampled_indices.push(min_index + start);
+                    // }
+                    sampled_indices.push(max_index + start);
+                    sampled_indices.push(min_index + start);
+                }
+
+                sampled_indices.push(end - 1);
             }
         }
     });
@@ -205,7 +198,7 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
                                 }
                             } // If the bin is empty, return empty Vec
                             None => {
-                                return vec![];
+                                vec![]
                             }
                         }
                     })

--- a/downsample_rs/src/m4/generic.rs
+++ b/downsample_rs/src/m4/generic.rs
@@ -164,28 +164,25 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
                             Some((start, end)) => {
                                 if end <= start + 4 {
                                     // If the bin has <= 4 elements, just return them all
-                                    (start..end).collect::<Vec<usize>>()
-                                } else {
-                                    // If the bin has > 4 elements, return the first and last + argmin and argmax
-                                    let step = unsafe {
-                                        ArrayView1::from_shape_ptr(
-                                            end - start,
-                                            arr.as_ptr().add(start),
-                                        )
-                                    };
-                                    let (min_index, max_index) = f_argminmax(step);
-
-                                    // Return the indexes in sorted order
-                                    let mut sampled_index = vec![start, 0, 0, end - 1];
-                                    if min_index < max_index {
-                                        sampled_index[1] = min_index + start;
-                                        sampled_index[2] = max_index + start;
-                                    } else {
-                                        sampled_index[1] = max_index + start;
-                                        sampled_index[2] = min_index + start;
-                                    }
-                                    sampled_index
+                                    return (start..end).collect::<Vec<usize>>();
                                 }
+
+                                // If the bin has > 4 elements, return the first and last + argmin and argmax
+                                let step = unsafe {
+                                    ArrayView1::from_shape_ptr(end - start, arr.as_ptr().add(start))
+                                };
+                                let (min_index, max_index) = f_argminmax(step);
+
+                                // Return the indexes in sorted order
+                                let mut sampled_index = vec![start, 0, 0, end - 1];
+                                if min_index < max_index {
+                                    sampled_index[1] = min_index + start;
+                                    sampled_index[2] = max_index + start;
+                                } else {
+                                    sampled_index[1] = max_index + start;
+                                    sampled_index[2] = min_index + start;
+                                }
+                                sampled_index
                             } // If the bin is empty, return empty Vec
                             None => {
                                 vec![]

--- a/downsample_rs/src/m4/scalar.rs
+++ b/downsample_rs/src/m4/scalar.rs
@@ -167,6 +167,72 @@ mod tests {
     }
 
     #[test]
+    fn test_m4_scalar_with_x_gap() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = m4_scalar_with_x(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 16); // One full gap
+        let expected_indices = vec![0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+
+        let sampled_indices = m4_scalar_with_x(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 17); // Gap with 1 value
+        let expected_indices = vec![
+            0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99, 100,
+        ];
+    }
+
+    #[test]
+    fn test_m4_scalar_with_x_gap_parallel() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = m4_scalar_with_x_parallel(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 16); // One full gap
+        let expected_indices = vec![0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+
+        let sampled_indices = m4_scalar_with_x_parallel(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 17); // Gap with 1 value
+        let expected_indices = vec![
+            0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99, 100,
+        ];
+    }
+
+    #[test]
     fn test_many_random_runs_correct() {
         let n: usize = 20_001; // not 20_000 because then the last bin is not "full"
         let x = (0..n as i32).collect::<Vec<i32>>();

--- a/downsample_rs/src/m4/simd.rs
+++ b/downsample_rs/src/m4/simd.rs
@@ -162,6 +162,39 @@ mod tests {
     }
 
     #[test]
+    fn test_m4_simd_with_x_gap() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = m4_simd_with_x(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 16); // One full gap
+        let expected_indices = vec![0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+
+        let sampled_indices = m4_simd_with_x(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 17); // Gap with 1 value
+        let expected_indices = vec![
+            0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99, 100,
+        ];
+    }
+
+    #[test]
     fn test_many_random_runs_correct() {
         let n = 20_001; // not 20_000 because then the last bin is not "full"
         let x = (0..n).map(|x| x as i32).collect::<Vec<i32>>();

--- a/downsample_rs/src/m4/simd.rs
+++ b/downsample_rs/src/m4/simd.rs
@@ -195,6 +195,39 @@ mod tests {
     }
 
     #[test]
+    fn test_m4_simd_with_x_gap_parallel() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = m4_simd_with_x_parallel(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 16); // One full gap
+        let expected_indices = vec![0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+
+        let sampled_indices = m4_simd_with_x_parallel(x.view(), arr.view(), 20);
+        assert_eq!(sampled_indices.len(), 17); // Gap with 1 value
+        let expected_indices = vec![
+            0, 0, 29, 29, 30, 30, 50, 50, 51, 51, 69, 69, 70, 70, 99, 99, 100,
+        ];
+    }
+
+    #[test]
     fn test_many_random_runs_correct() {
         let n = 20_001; // not 20_000 because then the last bin is not "full"
         let x = (0..n).map(|x| x as i32).collect::<Vec<i32>>();

--- a/downsample_rs/src/minmax/generic.rs
+++ b/downsample_rs/src/minmax/generic.rs
@@ -149,7 +149,7 @@ pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
                                     return vec![start];
                                 }
 
-                                // If the bin has at least two elements, add the argmin and argmax
+                                // If the bin has at least two elements, return the argmin and argmax
                                 let step = unsafe {
                                     ArrayView1::from_shape_ptr(end - start, arr.as_ptr().add(start))
                                 };

--- a/downsample_rs/src/minmax/generic.rs
+++ b/downsample_rs/src/minmax/generic.rs
@@ -167,31 +167,11 @@ pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
                                 } else {
                                     vec![max_index + start, min_index + start]
                                 }
-                            } // If the bin is empty, do nothing
+                            } // If the bin is empty, return empty Vec
                             None => {
-                                // Do nothing
                                 return vec![];
                             }
                         }
-
-                        // // TODO: explore the use of smallvec
-                        // if start + 1 == end {
-                        //     // If the bin has only one element, return it
-                        //     return vec![start];
-                        // }
-
-                        // // Get the index of the min and max of the bin
-                        // let step = unsafe {
-                        //     ArrayView1::from_shape_ptr(end - start, arr.as_ptr().add(start))
-                        // };
-                        // let (min_index, max_index) = f_argminmax(step);
-
-                        // // Return the indexes in sorted order
-                        // if min_index < max_index {
-                        //     vec![min_index + start, max_index + start]
-                        // } else {
-                        //     vec![max_index + start, min_index + start]
-                        // }
                     })
                     .collect::<Vec<Vec<usize>>>()
             })

--- a/downsample_rs/src/minmax/generic.rs
+++ b/downsample_rs/src/minmax/generic.rs
@@ -102,9 +102,11 @@ pub(crate) fn min_max_generic_with_x<T: Copy>(
 
     bin_idx_iterator.for_each(|bin| {
         if let Some((start, end)) = bin {
-            if start + 1 == end {
-                // If the bin has only one element, add it
-                sampled_indices.push(start)
+            if end <= start + 2 {
+                // If the bin has <= 2 elements, just add them all
+                for i in start..end {
+                    sampled_indices.push(i);
+                }
             } else {
                 // If the bin has at least two elements, add the argmin and argmax
                 let step = unsafe { ArrayView1::from_shape_ptr(end - start, ptr.add(start)) };
@@ -144,9 +146,9 @@ pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
                     .map(|bin| {
                         match bin {
                             Some((start, end)) => {
-                                if start + 1 == end {
-                                    // If the bin has only one element, return it
-                                    return vec![start];
+                                if end <= start + 2 {
+                                    // If the bin has <= 2 elements, just return them all
+                                    return (start..end).collect::<Vec<usize>>();
                                 }
 
                                 // If the bin has at least two elements, return the argmin and argmax

--- a/downsample_rs/src/minmax/generic.rs
+++ b/downsample_rs/src/minmax/generic.rs
@@ -101,29 +101,23 @@ pub(crate) fn min_max_generic_with_x<T: Copy>(
     let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out);
 
     bin_idx_iterator.for_each(|bin| {
-        match bin {
-            Some((start, end)) => {
-                if start + 1 == end {
-                    // If the bin has only one element, add it
-                    sampled_indices.push(start)
-                } else {
-                    // If the bin has at least two elements, add the argmin and argmax
-                    let step = unsafe { ArrayView1::from_shape_ptr(end - start, ptr.add(start)) };
-                    let (min_index, max_index) = f_argminmax(step);
+        if let Some((start, end)) = bin {
+            if start + 1 == end {
+                // If the bin has only one element, add it
+                sampled_indices.push(start)
+            } else {
+                // If the bin has at least two elements, add the argmin and argmax
+                let step = unsafe { ArrayView1::from_shape_ptr(end - start, ptr.add(start)) };
+                let (min_index, max_index) = f_argminmax(step);
 
-                    // Add the indexes in sorted order
-                    if min_index < max_index {
-                        sampled_indices.push(min_index + start);
-                        sampled_indices.push(max_index + start);
-                    } else {
-                        sampled_indices.push(max_index + start);
-                        sampled_indices.push(min_index + start);
-                    }
+                // Add the indexes in sorted order
+                if min_index < max_index {
+                    sampled_indices.push(min_index + start);
+                    sampled_indices.push(max_index + start);
+                } else {
+                    sampled_indices.push(max_index + start);
+                    sampled_indices.push(min_index + start);
                 }
-            }
-            // If the bin is empty, do nothing
-            None => {
-                // Do nothing
             }
         }
     });
@@ -169,7 +163,7 @@ pub(crate) fn min_max_generic_with_x_parallel<T: Copy + Send + Sync>(
                                 }
                             } // If the bin is empty, return empty Vec
                             None => {
-                                return vec![];
+                                vec![]
                             }
                         }
                     })

--- a/downsample_rs/src/minmax/scalar.rs
+++ b/downsample_rs/src/minmax/scalar.rs
@@ -170,6 +170,72 @@ mod tests {
     }
 
     #[test]
+    fn test_min_max_scalar_with_x_gap() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = min_max_scalar_with_x(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 8); // One full gap
+        let expected_indices = vec![0, 29, 30, 50, 51, 69, 70, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        println!("{:?}", x);
+        let x = Array1::from(x);
+
+        let sampled_indices = min_max_scalar_with_x(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 9); // Gap with 1 value
+        let expected_indices = vec![0, 39, 40, 50, 51, 52, 59, 60, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+    }
+
+    #[test]
+    fn test_min_max_scalar_with_x_parallel_gap() {
+        // Create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = min_max_scalar_with_x_parallel(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 8); // One full gap
+        let expected_indices = vec![0, 29, 30, 50, 51, 69, 70, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        println!("{:?}", x);
+        let x = Array1::from(x);
+
+        let sampled_indices = min_max_scalar_with_x_parallel(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 9); // Gap with 1 value
+        let expected_indices = vec![0, 39, 40, 50, 51, 52, 59, 60, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+    }
+
+    #[test]
     fn test_many_random_runs_same_output() {
         let n: usize = 20_001;
         let n_out = 200;

--- a/downsample_rs/src/minmax/scalar.rs
+++ b/downsample_rs/src/minmax/scalar.rs
@@ -193,7 +193,6 @@ mod tests {
             .iter()
             .map(|x| if *x > 101 { *x + 50 } else { *x })
             .collect::<Vec<i32>>();
-        println!("{:?}", x);
         let x = Array1::from(x);
 
         let sampled_indices = min_max_scalar_with_x(x.view(), arr.view(), 10);

--- a/downsample_rs/src/minmax/simd.rs
+++ b/downsample_rs/src/minmax/simd.rs
@@ -171,6 +171,72 @@ mod tests {
     }
 
     #[test]
+    fn test_min_max_simd_with_x_gap() {
+        // We will create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = min_max_simd_with_x(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 8); // One full gap
+        let expected_indices = vec![0, 29, 30, 50, 51, 69, 70, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        println!("{:?}", x);
+        let x = Array1::from(x);
+
+        let sampled_indices = min_max_simd_with_x(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 9); // Gap with 1 value
+        let expected_indices = vec![0, 39, 40, 50, 51, 52, 59, 60, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+    }
+
+    #[test]
+    fn test_min_max_simd_with_x_parallel_gap() {
+        // Create a gap in the middle of the array
+        let x = (0..101).collect::<Vec<i32>>();
+
+        // Increment the second half of the array by 50
+        let x = x
+            .iter()
+            .map(|x| if *x > 50 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        let x = Array1::from(x);
+        let arr = (0..101).map(|x| x as f32).collect::<Vec<f32>>();
+        let arr = Array1::from(arr);
+
+        let sampled_indices = min_max_simd_with_x_parallel(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 8); // One full gap
+        let expected_indices = vec![0, 29, 30, 50, 51, 69, 70, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+
+        // Increment the second half of the array by 50 again
+        let x = x
+            .iter()
+            .map(|x| if *x > 101 { *x + 50 } else { *x })
+            .collect::<Vec<i32>>();
+        println!("{:?}", x);
+        let x = Array1::from(x);
+
+        let sampled_indices = min_max_simd_with_x_parallel(x.view(), arr.view(), 10);
+        assert_eq!(sampled_indices.len(), 9); // Gap with 1 value
+        let expected_indices = vec![0, 39, 40, 50, 51, 52, 59, 60, 99];
+        assert_eq!(sampled_indices, Array1::from(expected_indices));
+    }
+
+    #[test]
     fn test_many_random_runs_same_output() {
         let n = 20_001;
         let n_out = 200;

--- a/downsample_rs/src/minmax/simd.rs
+++ b/downsample_rs/src/minmax/simd.rs
@@ -194,7 +194,6 @@ mod tests {
             .iter()
             .map(|x| if *x > 101 { *x + 50 } else { *x })
             .collect::<Vec<i32>>();
-        println!("{:?}", x);
         let x = Array1::from(x);
 
         let sampled_indices = min_max_simd_with_x(x.view(), arr.view(), 10);

--- a/downsample_rs/src/searchsorted.rs
+++ b/downsample_rs/src/searchsorted.rs
@@ -62,37 +62,6 @@ fn binary_search_with_mid<T: Copy + PartialOrd>(
 
 // --- Sequential version
 
-// pub(crate) fn get_equidistant_bin_idx_iterator<T>(
-//     arr: ArrayView1<T>,
-//     nb_bins: usize,
-// ) -> impl Iterator<Item = (usize, usize)> + '_
-// where
-//     T: Num + FromPrimitive + AsPrimitive<f64>,
-// {
-//     assert!(nb_bins >= 2);
-//     // Divide by nb_bins to avoid overflow!
-//     let val_step: f64 =
-//         (arr[arr.len() - 1].as_() / nb_bins as f64) - (arr[0].as_() / nb_bins as f64);
-//     let idx_step: usize = arr.len() / nb_bins; // used to pre-guess the mid index
-//     let mut value: f64 = arr[0].as_(); // Search value
-//     let mut idx: usize = 0; // Index of the search value
-//     (0..nb_bins).map(move |_| {
-//         let start_idx: usize = idx; // Start index of the bin (previous end index)
-//         value += val_step;
-//         let mid: usize = idx + idx_step;
-//         let mid = if mid < arr.len() - 1 {
-//             mid
-//         } else {
-//             arr.len() - 2 // TODO: arr.len() - 1 gives error I thought...
-//         };
-//         let search_value: T = T::from_f64(value).unwrap();
-//         // Implementation WITHOUT pre-guessing mid is slower!!
-//         // idx = binary_search(arr, search_value, idx, arr.len()-1);
-//         idx = binary_search_with_mid(arr, search_value, idx, arr.len() - 1, mid); // End index of the bin
-//         (start_idx, idx)
-//     })
-// }
-
 pub(crate) fn get_equidistant_bin_idx_iterator<T>(
     arr: ArrayView1<T>,
     nb_bins: usize,

--- a/downsample_rs/src/searchsorted.rs
+++ b/downsample_rs/src/searchsorted.rs
@@ -70,29 +70,29 @@ where
     T: Num + FromPrimitive + AsPrimitive<f64>,
 {
     assert!(nb_bins >= 2);
+    // 1. Compute the step between each bin
     // Divide by nb_bins to avoid overflow!
     let val_step: f64 =
         (arr[arr.len() - 1].as_() / nb_bins as f64) - (arr[0].as_() / nb_bins as f64);
-    let idx_step: usize = arr.len() / nb_bins; // used to pre-guess the mid index
+    // Estimate the step between each index (used to pre-guess the mid index)
+    let idx_step: usize = arr.len() / nb_bins;
+    // 2. The moving index & value
     let mut value: f64 = arr[0].as_(); // Search value
     let mut idx: usize = 0; // Index of the search value
+                            // 3. Iterate over the bins
     (0..nb_bins).map(move |_| {
         let start_idx: usize = idx; // Start index of the bin (previous end index)
+                                    // Update the search value
         value += val_step;
         let search_value: T = T::from_f64(value).unwrap();
         if arr[start_idx] >= search_value {
-            // If the first value of the bin is already >= the search value, then the
-            // bin is empty.
+            // If the first value of the bin is already >= the search value,
+            // then the bin is empty.
             return None;
         }
-        let mid: usize = idx + idx_step;
-        let mid = if mid < arr.len() - 1 {
-            mid
-        } else {
-            arr.len() - 2 // TODO: arr.len() - 1 gives error I thought...
-        };
-        // Implementation WITHOUT pre-guessing mid is slower!!
-        // idx = binary_search(arr, search_value, idx, arr.len()-1);
+        // Update the pre-guess index
+        let mid: usize = std::cmp::min(idx + idx_step, arr.len() - 1);
+        // TODO: Implementation WITHOUT pre-guessing mid is slower!!
         idx = binary_search_with_mid(arr, search_value, idx, arr.len() - 1, mid); // End index of the bin
         Some((start_idx, idx))
     })
@@ -118,26 +118,26 @@ where
     T: Num + FromPrimitive + AsPrimitive<f64> + Sync + Send,
 {
     assert!(nb_bins >= 2);
+    // 1. Compute the step between each bin
     // Divide by nb_bins to avoid overflow!
     let val_step: f64 =
         (arr[arr.len() - 1].as_() / nb_bins as f64) - (arr[0].as_() / nb_bins as f64);
-    let arr0: f64 = arr[0].as_();
+    let arr0: f64 = arr[0].as_(); // The first value of the array
+                                  // 2. Compute the number of threads & bins per thread
     let nb_threads = available_parallelism().map(|x| x.get()).unwrap_or(1);
-    let nb_threads = if nb_threads > nb_bins {
-        nb_bins
-    } else {
-        nb_threads
-    };
+    let nb_threads = std::cmp::min(nb_threads, nb_bins);
     let nb_bins_per_thread = nb_bins / nb_threads;
     let nb_bins_last_thread = nb_bins - nb_bins_per_thread * (nb_threads - 1);
-    // Iterate over the number of threads
+    // 3. Iterate over the number of threads
     // -> for each thread perform the binary search sorted with moving left and
     // yield the indices (using the same idea as for the sequential version)
     (0..nb_threads).into_par_iter().map(move |i| {
-        // Search the start of the fist bin o(f the thread)
+        // The moving index & value (for the thread)
         let mut value: f64 = sequential_add_mul(arr0, val_step, i * nb_bins_per_thread); // Search value
         let start_value: T = T::from_f64(value).unwrap();
+        // Search the start of the fist bin (of the thread)
         let mut idx: usize = binary_search(arr, start_value, 0, arr.len() - 1); // Index of the search value
+                                                                                // The number of bins for the thread
         let nb_bins_thread = if i == nb_threads - 1 {
             nb_bins_last_thread
         } else {
@@ -146,11 +146,12 @@ where
         // Perform sequential binary search for the end of the bins (of the thread)
         (0..nb_bins_thread).map(move |_| {
             let start_idx: usize = idx; // Start index of the bin (previous end index)
+                                        // Update the search value
             value += val_step;
             let search_value: T = T::from_f64(value).unwrap();
             if arr[start_idx] >= search_value {
-                // If the first value of the bin is already >= the search value, then the
-                // bin is empty.
+                // If the first value of the bin is already >= the search value,
+                // then the bin is empty.
                 return None;
             }
             idx = binary_search(arr, search_value, idx, arr.len() - 1); // End index of the bin

--- a/downsample_rs/src/searchsorted.rs
+++ b/downsample_rs/src/searchsorted.rs
@@ -91,7 +91,7 @@ where
             return None;
         }
         // Update the pre-guess index
-        let mid: usize = std::cmp::min(idx + idx_step, arr.len() - 1);
+        let mid: usize = std::cmp::min(idx + idx_step, arr.len() - 2);
         // TODO: Implementation WITHOUT pre-guessing mid is slower!!
         idx = binary_search_with_mid(arr, search_value, idx, arr.len() - 1, mid); // End index of the bin
         Some((start_idx, idx))

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -98,6 +98,25 @@ def test_downsampling_with_x():
         assert np.all(s_downsampled == s_downsampled_x)
 
 
+## Gaps in x
+
+
+def test_downsampling_with_gaps_in_x():
+    """Test downsampling with gaps in x.
+
+    With gap we do NOT mean a NaN in the array, but a large gap in the x values.
+    """
+    # TODO: might improve this test, now we just validate that the code does
+    # not crash
+    arr = np.random.randn(10_000).astype(np.float32)
+    idx = np.arange(len(arr))
+    idx[: len(idx) // 2] += len(idx) // 2  # add large gap in x
+    for downsampler in all_downsamplers:
+        s_downsampled = downsampler.downsample(idx, arr, n_out=100)
+        assert len(s_downsampled) <= 100
+        assert len(s_downsampled) >= 66
+
+
 ## Data types
 
 


### PR DESCRIPTION
The current implementation crashed when there are gaps in the `x` (i.e., an equidistant x-bin that does not contain any datapoints). 

To overcome this issue we now handle gaps 
- in the searchsorted functionality (aka the equidistant binning) by returning None when the bin is empty  
-> the output type of the Iterator is thus now `Option<(usize, usize)>`
- in the `M4` and `MinMax` generic code we check if the bin_size is <= 4 for M4 and 2 for minmax and then add all the indices
-> the othter case is the default implementation (as was before)

Code updates:
- [x] handle gaps for MinMax
- [x] test this 
- [x] handle gaps for M4
- [x] test this
- [x] add Python tests

TODO: 
- [x] check performance impact

Benches on the `gaps` branch :arrow_down: 
```bash
minmax_scalx_50M_f32    time:   [47.923 ms 48.396 ms 49.009 ms]
minmax_simdx_50M_f32    time:   [18.414 ms 18.586 ms 18.924 ms]
minmax_scalx_p_50M_f32  time:   [5.0812 ms 5.1216 ms 5.1748 ms]
minmax_simdx_p_50M_f32  time:   [4.0378 ms 4.0979 ms 4.1694 ms]

m4_scalx_50M_f32        time:   [46.977 ms 47.279 ms 47.669 ms]
m4_simdx_50M_f32        time:   [18.329 ms 18.441 ms 18.659 ms]
m4_scalx_p_50M_f32      time:   [7.3339 ms 7.4294 ms 7.5635 ms]
m4_simdx_p_50M_f32      time:   [4.8553 ms 4.8932 ms 4.9480 ms]

mlttb_scalx_50M_f32     time:   [66.573 ms 66.716 ms 66.881 ms]
mlttb_simdx_50M_f32     time:   [39.012 ms 39.743 ms 40.736 ms]
mlttb_scalx_p_50M_f32   time:   [13.433 ms 13.916 ms 14.530 ms]
mlttb_simdx_p_50M_f32   time:   [12.676 ms 12.772 ms 12.875 ms]
```

Benches on the `main` branch :arrow_down:
```bash
minmax_scalx_50M_f32    time:   [50.004 ms 51.015 ms 52.223 ms]
minmax_simdx_50M_f32    time:   [22.209 ms 22.425 ms 22.749 ms]
minmax_scalx_p_50M_f32  time:   [4.7367 ms 4.7549 ms 4.7757 ms]
minmax_simdx_p_50M_f32  time:   [3.8919 ms 3.9095 ms 3.9282 ms]

m4_scalx_50M_f32        time:   [49.127 ms 49.451 ms 49.871 ms]
m4_simdx_50M_f32        time:   [18.848 ms 18.865 ms 18.883 ms]
m4_scalx_p_50M_f32      time:   [7.2405 ms 7.2528 ms 7.2660 ms]
m4_simdx_p_50M_f32      time:   [4.9203 ms 4.9338 ms 4.9486 ms]

mlttb_scalx_50M_f32     time:   [66.978 ms 67.068 ms 67.170 ms]
mlttb_simdx_50M_f32     time:   [42.044 ms 43.382 ms 45.161 ms]
mlttb_scalx_p_50M_f32   time:   [13.511 ms 14.040 ms 14.689 ms]
mlttb_simdx_p_50M_f32   time:   [13.285 ms 13.666 ms 14.202 ms]
```

=> no *real* statistical differences :)


---

*Some remarks :thinking:*
:arrow_right: The most beautiful & flexible code update would be to alter the `get_equidistant_bins` to not return an (start, end) when the start & end are the same value (i.e., an empty bin).
-> ~I might revert the first commit & look into smth like that~ performed this in PR #25 
