### PR TITLE
:pen: improve readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
 
 The following downsampling algorithms (classes) are implemented:
 
-| Downsampler | Description | `# bins` | `**kwargs` |
-| --- | --- | --- | --- |
-| `MinMaxDownsampler` | selects the **min and max** value in each bin | `n_out` / 2 | `parallel` |
-| `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `n_out` / 4 | `parallel` |
-| `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `n_out` - 2 | |
-| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | *N.A.* | `parallel`, `minmax_ratio`<sup>*</sup> |
+| Downsampler | Description | `**kwargs` |
+| ---:| --- |--- |
+| `MinMaxDownsampler` | selects the **min and max** value in each bin | `parallel` |
+| `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `parallel` |
+| `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm |
+| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `parallel`, `minmax_ratio`<sup>*</sup> |
 
 <sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default.</i>
 
@@ -102,7 +102,7 @@ The following downsampling algorithms (classes) are implemented:
 ## Limitations & assumptions 🚨
 
 Assumes;
-1. `x`-data monotonic increasing (i.e., sorted)
+1. `x`-data is (non-strictly) monotonic increasing (i.e., sorted)
 2. no `NaNs` in the data
 
 ---

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ s_ds = MinMaxLTTBDownsampler().downsample(x, y, n_out=1000)
 
 ### Downsampling API 📑
 
-Each downsampling algorithm is implemented as a class that implements a `downsample` method. The signature of the `downsample` method:
+Each downsampling algorithm is implemented as a class that implements a `downsample` method.  
+The signature of the `downsample` method:
 
 ```
 downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
@@ -96,7 +97,7 @@ The following downsampling algorithms (classes) are implemented:
 | `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm |
 | `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `parallel`, `minmax_ratio`<sup>*</sup> |
 
-<sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default.</i>
+<sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default. (More details in our upcomming paper)</i>
 
 
 ## Limitations & assumptions 🚨

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 [![Testing](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-tsdownsample.yml/badge.svg)](https://github.com/predict-idlab/tsdownsample/actions/workflows/ci-tsdownsample.yml)
 <!-- TODO: codecov -->
 
-Extremely fast **📈 time series downsampling** for visualization, written in Rust.
+Extremely fast **time series downsampling 📈** for visualization, written in Rust.
 
 ## Features ✨
 
 * **Fast**: written in rust with PyO3 bindings  
   - leverages optimized [argminmax](https://github.com/jvdd/argminmax) - which is SIMD accelerated with runtime feature detection
   - scales linearly with the number of data points
+  <!-- TODO check if it scales sublinearly -->
   - multithreaded with Rayon (in Rust)
     <details>
       <summary><i>Why we do not use Python multiprocessing</i></summary>
@@ -62,6 +63,35 @@ s_ds = MinMaxLTTBDownsampler().downsample(y, n_out=1000)
 s_ds = MinMaxLTTBDownsampler().downsample(x, y, n_out=1000)
 ```
 
+## Downsampling algorithms & API 
+
+### Downsampling API 📑
+
+Each downsampling algorithm is implemented as a class that implements a `downsample` method. The signature of the `downsample` method:
+
+```
+downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
+```
+
+**Arguments**:
+- `x` is optional
+- `x` and `y` are both positional arguments
+- `n_out` is a mandatory keyword argument that defines the number of output values
+- `**kwargs` are optional keyword arguments:
+  <!-- - `n_threads`: number of threads to use (default: `None` - use all available threads) -->
+  - `parallel`: whether to use multi-threading (default: `False`)
+
+**Returns**: a `ndarray[uint64]` of indices that can be used to index the original data.
+
+
+### Downsampling algorithms 📈
+
+The following downsampling algorithms (classes) are implemented:
+- `MinMaxDownsampler`: downsamples by selecting the min and max value in each bin. `n_out` / 2 bins are created.
+- `M4Downsampler`: downsamples by selecting the min, max, 1st and last value in each bin. `n_out` / 4 bins are created.
+- `LTTBDownsampler`: downsamples according to the [Largest Triangle Three Buckets](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm. `n_out` - 2 bins are created.
+- `MinMaxLTTBDownsampler`: **novel downsampling algorithm 🎉** that combines the `MinMaxDownsampler` and `LTTBDownsampler` algorithms. `n_out` - 2 bins are created.
+  - ❗(optional) keyword argument `minmax_ratio`: the ratio of the number of min/max values to the `n_out` value. Default: `30` (i.e., 30x the `n_out` values are prefetched by MinMaxDownsampler).
 ## Limitations
 
 Assumes;

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
 - `x` and `y` are both positional arguments
 - `n_out` is a mandatory keyword argument that defines the number of output values<sup>*</sup>
 - `**kwargs` are optional keyword arguments *(see [table below](#downsampling-algorithms-📈))*:
-  <!-- - `n_threads`: number of threads to use (default: `None` - use all available threads) -->
   - `parallel`: whether to use multi-threading (default: `False`)<sup>**</sup>
   - ...
 
@@ -88,26 +87,19 @@ downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
 <sup>**</sup><i>`parallel` is not supported for `LTTBDownsampler`.</i>
 ### Downsampling algorithms 📈
 
-<!-- The following downsampling algorithms (classes) are implemented:
-- `MinMaxDownsampler`: downsamples by selecting the min and max value in each bin. `n_out` / 2 bins are created.
-- `M4Downsampler`: downsamples by selecting the min, max, 1st and last value in each bin. `n_out` / 4 bins are created.
-- `LTTBDownsampler`: downsamples according to the [Largest Triangle Three Buckets](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm. `n_out` - 2 bins are created.
-- `MinMaxLTTBDownsampler`: **novel downsampling algorithm 🎉** that combines the `MinMaxDownsampler` and `LTTBDownsampler` algorithms. `n_out` - 2 bins are created.
-  - ❗(optional) keyword argument `minmax_ratio`: the ratio of the number of min/max values to the `n_out` value. Default: `30` (i.e., 30x the `n_out` values are prefetched by MinMaxDownsampler). -->
-
-<!-- Table of the downsampling algorithms -->
+The following downsampling algorithms (classes) are implemented:
 
 | Downsampler | Description | `# bins` | `**kwargs` |
 | --- | --- | --- | --- |
 | `MinMaxDownsampler` | selects the **min and max** value in each bin | `n_out` / 2 | `parallel` |
 | `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `n_out` / 4 | `parallel` |
 | `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `n_out` - 2 | |
-| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `parallel`, `minmax_ratio`<sup>*</sup> |
+| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | *N.A.* | `parallel`, `minmax_ratio`<sup>*</sup> |
 
 <sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default.</i>
 
 
-## Limitations
+## Limitations & assumptions 🚨
 
 Assumes;
 1. `x`-data monotonic increasing (i.e., sorted)

--- a/README.md
+++ b/README.md
@@ -76,27 +76,42 @@ downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
 **Arguments**:
 - `x` is optional
 - `x` and `y` are both positional arguments
-- `n_out` is a mandatory keyword argument that defines the number of output values
-- `**kwargs` are optional keyword arguments:
+- `n_out` is a mandatory keyword argument that defines the number of output values<sup>*</sup>
+- `**kwargs` are optional keyword arguments *(see [table below](#downsampling-algorithms-📈))*:
   <!-- - `n_threads`: number of threads to use (default: `None` - use all available threads) -->
-  - `parallel`: whether to use multi-threading (default: `False`)
+  - `parallel`: whether to use multi-threading (default: `False`)<sup>**</sup>
+  - ...
 
 **Returns**: a `ndarray[uint64]` of indices that can be used to index the original data.
 
-
+<sup>*</sup><i>When there are gaps in the time series, fewer than `n_out` indices may be returned.</i>  
+<sup>**</sup><i>`parallel` is not supported for `LTTBDownsampler`.</i>
 ### Downsampling algorithms 📈
 
-The following downsampling algorithms (classes) are implemented:
+<!-- The following downsampling algorithms (classes) are implemented:
 - `MinMaxDownsampler`: downsamples by selecting the min and max value in each bin. `n_out` / 2 bins are created.
 - `M4Downsampler`: downsamples by selecting the min, max, 1st and last value in each bin. `n_out` / 4 bins are created.
 - `LTTBDownsampler`: downsamples according to the [Largest Triangle Three Buckets](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm. `n_out` - 2 bins are created.
 - `MinMaxLTTBDownsampler`: **novel downsampling algorithm 🎉** that combines the `MinMaxDownsampler` and `LTTBDownsampler` algorithms. `n_out` - 2 bins are created.
-  - ❗(optional) keyword argument `minmax_ratio`: the ratio of the number of min/max values to the `n_out` value. Default: `30` (i.e., 30x the `n_out` values are prefetched by MinMaxDownsampler).
+  - ❗(optional) keyword argument `minmax_ratio`: the ratio of the number of min/max values to the `n_out` value. Default: `30` (i.e., 30x the `n_out` values are prefetched by MinMaxDownsampler). -->
+
+<!-- Table of the downsampling algorithms -->
+
+| Downsampler | Description | `# bins` | `**kwargs` |
+| --- | --- | --- | --- |
+| `MinMaxDownsampler` | selects the **min and max** value in each bin | `n_out` / 2 | `parallel` |
+| `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `n_out` / 4 | `parallel` |
+| `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `n_out` - 2 | |
+| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `parallel`, `minmax_ratio`<sup>*</sup> |
+
+<sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default.</i>
+
+
 ## Limitations
 
 Assumes;
-(i) x-data monotinically increasing (i.e., sorted)
-(ii) no NaNs in the data
+1. `x`-data monotonic increasing (i.e., sorted)
+2. no `NaNs` in the data
 
 ---
 


### PR DESCRIPTION
Adds the following to the `README.md`:
- signature of the `.downsample` methdod(s)
- short description of the implemented downsampling algorithms (aka the classes)
  - add the supported `**kwargs`