### PR TITLE
:ribbon: use `Option` for searchsorted + fix gaps bug for M4

### DIFF
--- a/downsample_rs/src/minmax/scalar.rs
+++ b/downsample_rs/src/minmax/scalar.rs
@@ -193,7 +193,6 @@ mod tests {
             .iter()
             .map(|x| if *x > 101 { *x + 50 } else { *x })
             .collect::<Vec<i32>>();
-        println!("{:?}", x);
         let x = Array1::from(x);
 
         let sampled_indices = min_max_scalar_with_x(x.view(), arr.view(), 10);

--- a/downsample_rs/src/minmax/simd.rs
+++ b/downsample_rs/src/minmax/simd.rs
@@ -194,7 +194,6 @@ mod tests {
             .iter()
             .map(|x| if *x > 101 { *x + 50 } else { *x })
             .collect::<Vec<i32>>();
-        println!("{:?}", x);
         let x = Array1::from(x);
 
         let sampled_indices = min_max_simd_with_x(x.view(), arr.view(), 10);


### PR DESCRIPTION
- [x] :package: use `Option` as searchsorted its output type
   -> returns None when an empty bin is detected.
- [x] :hole: fix gaps bug for `M4` algorithm