### PR TITLE
Bump maturin version: 0.14 -> 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,6 @@ description = "Python bindings for time series downsampling algorithms"
 repository = "https://github.com/predict-idlab/tsdownsample"
 license = "MIT"
 
-[package.metadata.maturin]
-# Import the Rust library under this path
-# See: https://www.maturin.rs/project_layout.html#import-rust-as-a-submodule-of-your-project
-name = "tsdownsample._rust._tsdownsample_rs"
-
 [dependencies]
 downsample_rs = { path = "downsample_rs", features = ["half"]}
 pyo3 = { version = "0.18", features = ["extension-module"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 
 [dependencies]
 downsample_rs = { path = "downsample_rs", features = ["half"]}
-pyo3 = { version = "0.18", features = ["extension-module"] }
-numpy = { version = "0.18", features = ["half"] }
+pyo3 = { version = "0.19", features = ["extension-module"] }
+numpy = { version = "0.19", features = ["half"] }
 half = { version = "2.1", default-features = false }
 paste = { version = "1.0.9", default-features = false }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.1,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -33,6 +33,8 @@ Repository = "https://github.com/predict-idlab/tsdownsample"
 # Build Python bindings for rust
 [tool.maturin]
 bindings = "pyo3"
+module-name = "tsdownsample._rust._tsdownsample_rs" # The path to place the compiled Rust module
+# See: https://www.maturin.rs/project_layout.html#import-rust-as-a-submodule-of-your-project
 
 # Linting
 [tool.ruff]


### PR DESCRIPTION
This PR bumps the maturin version from `0.14` to `1.1`

It also replaces the usage of `[package.metadata.maturin].name` with `[tool.maturin].module-name`.

(the former one has been deprecated since `0.15`)

---
I made this change, as I'm trying to package this Python package for [nixpkgs](https://github.com/nixOS/nixpkgs/) and it uses a newer version of maturin, so I had to patch the `pyproject.toml` with the output path. This PR just that patch as a commit.

