### PR TITLE
:see_no_evil: change default `minmax_ratio` to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The following downsampling algorithms (classes) are implemented:
 | `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `n_threads` |
 | `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `n_threads`, `minmax_ratio`<sup>*</sup> |
 
-<sup>*</sup><i>Default value for `minmax_ratio` is 30, which is empirically proven to be a good default. (More details in our upcomming paper)</i>
+<sup>*</sup><i>Default value for `minmax_ratio` is 4, which is empirically proven to be a good default. More details here: https://arxiv.org/abs/2305.00332</i>
 
 
 ## Limitations & assumptions 🚨

--- a/downsample_rs/src/m4.rs
+++ b/downsample_rs/src/m4.rs
@@ -75,7 +75,7 @@ where
 //    be the start and end of the bin, which would result in duplicate data in
 //    the output array. (this is for example the case for monotonic data).
 
-// ----------------- GENERICS
+// ----------------------------------- GENERICS ------------------------------------
 
 // --------------------- WITHOUT X
 

--- a/downsample_rs/src/minmax.rs
+++ b/downsample_rs/src/minmax.rs
@@ -69,8 +69,9 @@ where
     assert_eq!(n_out % 2, 0);
     min_max_generic_parallel(arr, n_out, n_threads, |arr| arr.argminmax())
 }
-// ----------------- GENERICS
-//
+
+// ----------------------------------- GENERICS ------------------------------------
+
 // --------------------- WITHOUT X
 
 #[inline(always)]

--- a/downsample_rs/src/minmaxlttb.rs
+++ b/downsample_rs/src/minmaxlttb.rs
@@ -208,8 +208,8 @@ where
                 .map(|i| *y.get_unchecked(*i))
                 .collect::<Vec<Ty>>()
         };
-        // Apply lttb on the reduced data
-        let index_points_selected = lttb_without_x(y.as_slice(), n_out);
+        // Apply lttb on the reduced data (using the preselect data its index)
+        let index_points_selected = lttb_with_x(index.as_slice(), y.as_slice(), n_out);
         // Return the original index
         return index_points_selected
             .iter()

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -45,7 +45,7 @@ class MinMaxLTTBDownsampler(AbstractRustDownsampler):
         return _tsdownsample_rs.minmaxlttb
 
     def downsample(
-        self, *args, n_out: int, minmax_ratio: int = 30, n_threads: int = 1, **_
+        self, *args, n_out: int, minmax_ratio: int = 4, n_threads: int = 1, **_
     ):
         assert minmax_ratio > 0, "minmax_ratio must be greater than 0"
         return super().downsample(


### PR DESCRIPTION
Changes the `minmax_ratio` to 4 (was previously 30) - this change is based on the empirical evidence gathered in our research on the MinMaxLTTB work; https://arxiv.org/abs/2305.00332 (in this paper `minmax_ratio` is called the "preselection ratio").

Note that in plotly-resasampler we already used 4 as default value (in the wrapper for this package); 
https://github.com/predict-idlab/plotly-resampler/blob/741da5d2358bee59c59d1591b0722ab0ea66bbb6/plotly_resampler/aggregation/aggregators.py#L211

This PR also fixes a minor bug when calling `MinMaxLTTB.downsample` (without an x array) -> the indices of the preselected data points  should be passed to the LTTB algorithm (2nd step of the algorithm) in order to have a more correct triangle surface calculation (-> will resemble more closesly vanilla LTTB behavior).

---

Credits are due to @raphaelvallat for uncovering this issue