### PR TITLE
Fix multithreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ downsample([x], y, n_out, **kwargs) -> ndarray[uint64]
 - `x` and `y` are both positional arguments
 - `n_out` is a mandatory keyword argument that defines the number of output values<sup>*</sup>
 - `**kwargs` are optional keyword arguments *(see [table below](#downsampling-algorithms-📈))*:
-  - `n_threads`: how many threads to use for multi-threading (default `1`, so no multi-threading)
+  - `parallel`: whether to use multi-threading (default: `False`)  
+     ❗ The max number of threads can be configured with the `TSDOWNSAMPLE_MAX_THREADS` ENV var (e.g. `os.environ["TSDOWNSAMPLE_MAX_THREADS"] = "4"`)
   - ...
 
 **Returns**: a `ndarray[uint64]` of indices that can be used to index the original data.
@@ -99,10 +100,10 @@ The following downsampling algorithms (classes) are implemented:
 
 | Downsampler | Description | `**kwargs` |
 | ---:| --- |--- |
-| `MinMaxDownsampler` | selects the **min and max** value in each bin | `n_threads` |
-| `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `n_threads` |
-| `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `n_threads` |
-| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `n_threads`, `minmax_ratio`<sup>*</sup> |
+| `MinMaxDownsampler` | selects the **min and max** value in each bin | `parallel` |
+| `M4Downsampler` | selects the [**min, max, first and last**](https://dl.acm.org/doi/pdf/10.14778/2732951.2732953) value in each bin | `parallel` |
+| `LTTBDownsampler` | performs the [**Largest Triangle Three Buckets**](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) algorithm | `parallel` |
+| `MinMaxLTTBDownsampler` | (*new two-step algorithm 🎉*) first selects `n_out` * `minmax_ratio` **min and max** values, then further reduces these to `n_out` values using the **Largest Triangle Three Buckets** algorithm | `parallel`, `minmax_ratio`<sup>*</sup> |
 
 <sup>*</sup><i>Default value for `minmax_ratio` is 4, which is empirically proven to be a good default. More details here: https://arxiv.org/abs/2305.00332</i>
 

--- a/downsample_rs/Cargo.toml
+++ b/downsample_rs/Cargo.toml
@@ -9,15 +9,15 @@ license = "MIT"
 [dependencies]
 # TODO: perhaps use polars?
 argminmax = { version = "0.6.1", features = ["half"] }
-# argminmax = { path = "../../argminmax" , features = ["half", "ndarray"] }
 half = { version = "2.1", default-features = false , features=["num-traits"], optional = true}
 num-traits = { version = "0.2.15", default-features = false }
-rayon = { version = "1.6.0", default-features = false }
+once_cell = "1"
+rayon = { version = "1.8.0", default-features = false }
 
 [dev-dependencies]
 rstest = { version = "0.18.1", default-features = false }
 rstest_reuse = { version = "0.6", default-features = false }
-criterion = "0.4.0"
+criterion = "0.5.1"
 dev_utils = { path = "dev_utils" }
 
 [[bench]]

--- a/downsample_rs/benches/bench_m4.rs
+++ b/downsample_rs/benches/bench_m4.rs
@@ -14,15 +14,8 @@ fn m4_f32_random_array_long_single_core(c: &mut Criterion) {
 fn m4_f32_random_array_long_multi_core(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("m4_p_f32", |b| {
-        b.iter(|| {
-            m4_mod::m4_without_x_parallel(
-                black_box(data.as_slice()),
-                black_box(2_000),
-                black_box(all_threads),
-            )
-        })
+        b.iter(|| m4_mod::m4_without_x_parallel(black_box(data.as_slice()), black_box(2_000)))
     });
 }
 
@@ -48,15 +41,8 @@ fn m4_f32_random_array_50M_multi_core(c: &mut Criterion) {
     let n = 50_000_000;
     let data = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
     let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("m4_p_50M_f32", |b| {
-        b.iter(|| {
-            m4_mod::m4_without_x_parallel(
-                black_box(data.as_slice()),
-                black_box(2_000),
-                black_box(all_threads),
-            )
-        })
+        b.iter(|| m4_mod::m4_without_x_parallel(black_box(data.as_slice()), black_box(2_000)))
     });
     c.bench_function("m4_x_p_50M_f32", |b| {
         b.iter(|| {
@@ -64,7 +50,6 @@ fn m4_f32_random_array_50M_multi_core(c: &mut Criterion) {
                 black_box(x.as_slice()),
                 black_box(data.as_slice()),
                 black_box(2_000),
-                black_box(all_threads),
             )
         })
     });

--- a/downsample_rs/benches/bench_minmax.rs
+++ b/downsample_rs/benches/bench_minmax.rs
@@ -14,14 +14,9 @@ fn minmax_f32_random_array_long_single_core(c: &mut Criterion) {
 fn minmax_f32_random_array_long_multi_core(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("minmax_p_f32", |b| {
         b.iter(|| {
-            minmax_mod::min_max_without_x_parallel(
-                black_box(data.as_slice()),
-                black_box(2_000),
-                black_box(all_threads),
-            )
+            minmax_mod::min_max_without_x_parallel(black_box(data.as_slice()), black_box(2_000))
         })
     });
 }
@@ -55,14 +50,9 @@ fn minmax_f32_random_array_50M_long_multi_core(c: &mut Criterion) {
     let n = 50_000_000;
     let data = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
     let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("minmax_p_50M_f32", |b| {
         b.iter(|| {
-            minmax_mod::min_max_without_x_parallel(
-                black_box(data.as_slice()),
-                black_box(2_000),
-                black_box(all_threads),
-            )
+            minmax_mod::min_max_without_x_parallel(black_box(data.as_slice()), black_box(2_000))
         })
     });
     c.bench_function("minmax_x_p_50M_f32", |b| {
@@ -71,7 +61,6 @@ fn minmax_f32_random_array_50M_long_multi_core(c: &mut Criterion) {
                 black_box(x.as_slice()),
                 black_box(data.as_slice()),
                 black_box(2_000),
-                black_box(all_threads),
             )
         })
     });

--- a/downsample_rs/benches/bench_minmaxlttb.rs
+++ b/downsample_rs/benches/bench_minmaxlttb.rs
@@ -25,7 +25,6 @@ fn minmaxlttb_f32_random_array_long_multi_core(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
     let y = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("mlttb_x_p_f32", |b| {
         b.iter(|| {
             minmaxlttb_mod::minmaxlttb_with_x_parallel(
@@ -33,7 +32,6 @@ fn minmaxlttb_f32_random_array_long_multi_core(c: &mut Criterion) {
                 black_box(y.as_slice()),
                 black_box(2_000),
                 black_box(MINMAX_RATIO),
-                black_box(all_threads),
             )
         })
     });
@@ -59,7 +57,6 @@ fn minmaxlttb_f32_random_array_50M_multi_core(c: &mut Criterion) {
     let n = 50_000_000;
     let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
     let y = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("mlttb_x_p_50M_f32", |b| {
         b.iter(|| {
             minmaxlttb_mod::minmaxlttb_with_x_parallel(
@@ -67,7 +64,6 @@ fn minmaxlttb_f32_random_array_50M_multi_core(c: &mut Criterion) {
                 black_box(y.as_slice()),
                 black_box(2_000),
                 black_box(MINMAX_RATIO),
-                black_box(all_threads),
             )
         })
     });
@@ -90,14 +86,12 @@ fn minmaxlttb_without_x_f32_random_array_50M_single_core(c: &mut Criterion) {
 fn minmaxlttb_without_x_f32_random_array_50M_multi_core(c: &mut Criterion) {
     let n = 50_000_000;
     let y = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
-    let all_threads: usize = utils::get_all_threads();
     c.bench_function("mlttb_p_50M_f32", |b| {
         b.iter(|| {
             minmaxlttb_mod::minmaxlttb_without_x_parallel(
                 black_box(y.as_slice()),
                 black_box(2_000),
                 black_box(MINMAX_RATIO),
-                black_box(all_threads),
             )
         })
     });

--- a/downsample_rs/dev_utils/src/utils.rs
+++ b/downsample_rs/dev_utils/src/utils.rs
@@ -33,11 +33,3 @@ where
     }
     arr
 }
-
-// ------------- Multi-threading -------------
-
-use std::thread::available_parallelism;
-
-pub fn get_all_threads() -> usize {
-    available_parallelism().map(|x| x.get()).unwrap_or(1)
-}

--- a/downsample_rs/src/lib.rs
+++ b/downsample_rs/src/lib.rs
@@ -14,3 +14,21 @@ pub use m4::*;
 pub(crate) mod helpers;
 pub(crate) mod searchsorted;
 pub(crate) mod types;
+
+use once_cell::sync::Lazy;
+use rayon::{ThreadPool, ThreadPoolBuilder};
+
+pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
+    ThreadPoolBuilder::new()
+        .num_threads(
+            std::env::var("TSDOWNSAMPLE_MAX_THREADS")
+                .map(|s| s.parse::<usize>().expect("integer"))
+                .unwrap_or_else(|_| {
+                    std::thread::available_parallelism()
+                        .unwrap_or(std::num::NonZeroUsize::new(1).unwrap())
+                        .get()
+                }),
+        )
+        .build()
+        .expect("could not spawn threads")
+});

--- a/downsample_rs/src/m4.rs
+++ b/downsample_rs/src/m4.rs
@@ -3,10 +3,11 @@ use num_traits::{AsPrimitive, FromPrimitive};
 use rayon::iter::IndexedParallelIterator;
 use rayon::prelude::*;
 
-use crate::searchsorted::{
+use super::searchsorted::{
     get_equidistant_bin_idx_iterator, get_equidistant_bin_idx_iterator_parallel,
 };
-use crate::types::Num;
+use super::types::Num;
+use super::POOL;
 
 // ----------------------------------- NON-PARALLEL ------------------------------------
 
@@ -137,39 +138,34 @@ pub(crate) fn m4_generic_parallel<T: Copy + PartialOrd + Send + Sync>(
     let block_size: f64 = (arr.len() - 1) as f64 / (n_out / 4) as f64;
 
     // Store the enumerated indexes in the output array
+    // These indexes are used to calculate the start and end indexes of each bin in
+    // the multi-threaded execution
     let mut sampled_indices: Vec<usize> = (0..n_out).collect::<Vec<usize>>();
 
-    // to limit the amounts of threads Rayon uses, an explicit threadpool needs to be created
-    // in which the required code is "installed". This limits the amount of used threads.
-    // https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html#method.install
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(n_threads)
-        .build();
+    POOL.install(|| {
+        sampled_indices
+            .par_chunks_exact_mut(4)
+            .for_each(|sampled_index_chunk| {
+                let i: f64 = unsafe { *sampled_index_chunk.get_unchecked(0) >> 2 } as f64;
+                let start_idx: usize = (block_size * i) as usize + (i != 0.0) as usize;
+                let end_idx: usize = (block_size * (i + 1.0)) as usize + 1;
 
-    let func = || {
-        for chunk in sampled_indices.chunks_exact_mut(4) {
-            let i: f64 = unsafe { *chunk.get_unchecked(0) >> 2 } as f64;
-            let start_idx: usize = (block_size * i) as usize + (i != 0.0) as usize;
-            let end_idx: usize = (block_size * (i + 1.0)) as usize + 1;
+                let (min_index, max_index) = f_argminmax(&arr[start_idx..end_idx]);
 
-            let (min_index, max_index) = f_argminmax(&arr[start_idx..end_idx]);
+                sampled_index_chunk[0] = start_idx;
+                // Add the indexes in sorted order
+                if min_index < max_index {
+                    sampled_index_chunk[1] = min_index + start_idx;
+                    sampled_index_chunk[2] = max_index + start_idx;
+                } else {
+                    sampled_index_chunk[1] = max_index + start_idx;
+                    sampled_index_chunk[2] = min_index + start_idx;
+                }
+                sampled_index_chunk[3] = end_idx - 1;
+            })
+    });
 
-            chunk[0] = start_idx;
-            // Add the indexes in sorted order
-            if min_index < max_index {
-                chunk[1] = min_index + start_idx;
-                chunk[2] = max_index + start_idx;
-            } else {
-                chunk[1] = max_index + start_idx;
-                chunk[2] = min_index + start_idx;
-            }
-            chunk[3] = end_idx - 1;
-        }
-    };
-
-    pool.unwrap().install(func); // allow panic if pool could not be created
-
-    sampled_indices.to_vec()
+    sampled_indices
 }
 
 // --------------------- WITH X
@@ -232,14 +228,7 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
         return (0..arr.len()).collect::<Vec<usize>>();
     }
 
-    // to limit the amounts of threads Rayon uses, an explicit threadpool needs to be created
-    // in which the required code is "installed". This limits the amount of used threads.
-    // https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html#method.install
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(n_threads)
-        .build();
-
-    let iter_func = || {
+    POOL.install(|| {
         bin_idx_iterator
             .flat_map(|bin_idx_iterator| {
                 bin_idx_iterator
@@ -275,10 +264,7 @@ pub(crate) fn m4_generic_with_x_parallel<T: Copy + PartialOrd + Send + Sync>(
             })
             .flatten()
             .collect::<Vec<usize>>()
-    };
-
-    let result = pool.unwrap().install(iter_func); // allow panic if pool could not be created
-    result
+    })
 }
 
 #[cfg(test)]

--- a/downsample_rs/src/m4.rs
+++ b/downsample_rs/src/m4.rs
@@ -420,7 +420,7 @@ mod tests {
             let idxs3 = m4_without_x_parallel(arr.as_slice(), n_out);
             let idxs4 = m4_with_x_parallel(&x, arr.as_slice(), n_out);
             assert_eq!(idxs1, idxs3);
-            assert_eq!(idxs1, idxs4); // TODO: this should not fail when n_threads = 16
+            assert_eq!(idxs1, idxs4); // TODO: this fails when nb. of threads = 16
         }
     }
 }

--- a/downsample_rs/src/searchsorted.rs
+++ b/downsample_rs/src/searchsorted.rs
@@ -2,6 +2,7 @@ use rayon::iter::IndexedParallelIterator;
 use rayon::prelude::*;
 
 use super::types::Num;
+use super::POOL;
 use num_traits::{AsPrimitive, FromPrimitive};
 
 // ---------------------- Binary search ----------------------
@@ -140,7 +141,7 @@ where
         (arr[arr.len() - 1].as_() / nb_bins as f64) - (arr[0].as_() / nb_bins as f64);
     let arr0: f64 = arr[0].as_(); // The first value of the array
                                   // 2. Compute the number of threads & bins per thread
-    let n_threads = std::cmp::min(n_threads, nb_bins);
+    let n_threads = std::cmp::min(POOL.current_num_threads(), nb_bins);
     let nb_bins_per_thread = nb_bins / n_threads;
     let nb_bins_last_thread = nb_bins - nb_bins_per_thread * (n_threads - 1);
     // 3. Iterate over the number of threads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "tsdownsample"
 description = "Time series downsampling in rust"
-version = "0.1.3rc1"
+version = "0.1.3rc2"
 requires-python = ">=3.7"
 dependencies = ["numpy"]
 authors = [{name = "Jeroen Van Der Donckt"}]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,25 +32,6 @@ macro_rules! _create_pyfunc_without_x {
     };
 }
 
-macro_rules! _create_pyfunc_without_x_multithreaded {
-    ($name:ident, $resample_mod:ident, $resample_fn:ident, $type:ty, $mod:ident) => {
-        // Create the Python function
-        #[pyfunction]
-        fn $name<'py>(
-            py: Python<'py>,
-            y: PyReadonlyArray1<$type>,
-            n_out: usize,
-            n_threads: usize,
-        ) -> &'py PyArray1<usize> {
-            let y = y.as_slice().unwrap();
-            let sampled_indices = $resample_mod::$resample_fn(y, n_out, n_threads);
-            sampled_indices.into_pyarray(py)
-        }
-        // Add the function to the module
-        $mod.add_wrapped(wrap_pyfunction!($name))?;
-    };
-}
-
 macro_rules! _create_pyfunc_without_x_with_ratio {
     ($name:ident, $resample_mod:ident, $resample_fn:ident, $type:ty, $mod:ident) => {
         // Create the Python function
@@ -63,26 +44,6 @@ macro_rules! _create_pyfunc_without_x_with_ratio {
         ) -> &'py PyArray1<usize> {
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(y, n_out, ratio);
-            sampled_indices.into_pyarray(py)
-        }
-        // Add the function to the module
-        $mod.add_wrapped(wrap_pyfunction!($name))?;
-    };
-}
-
-macro_rules! _create_pyfunc_without_x_with_ratio_multithreaded {
-    ($name:ident, $resample_mod:ident, $resample_fn:ident, $type:ty, $mod:ident) => {
-        // Create the Python function
-        #[pyfunction]
-        fn $name<'py>(
-            py: Python<'py>,
-            y: PyReadonlyArray1<$type>,
-            n_out: usize,
-            ratio: usize,
-            n_threads: usize,
-        ) -> &'py PyArray1<usize> {
-            let y = y.as_slice().unwrap();
-            let sampled_indices = $resample_mod::$resample_fn(y, n_out, ratio, n_threads);
             sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
@@ -122,27 +83,6 @@ macro_rules! _create_pyfunc_with_x {
     };
 }
 
-macro_rules! _create_pyfunc_with_x_multithreaded {
-    ($name:ident, $resample_mod:ident, $resample_fn:ident, $type_x:ty, $type_y:ty, $mod:ident) => {
-        // Create the Python function
-        #[pyfunction]
-        fn $name<'py>(
-            py: Python<'py>,
-            x: PyReadonlyArray1<$type_x>,
-            y: PyReadonlyArray1<$type_y>,
-            n_out: usize,
-            n_threads: usize,
-        ) -> &'py PyArray1<usize> {
-            let x = x.as_slice().unwrap();
-            let y = y.as_slice().unwrap();
-            let sampled_indices = $resample_mod::$resample_fn(x, y, n_out, n_threads);
-            sampled_indices.into_pyarray(py)
-        }
-        // Add the function to the module
-        $mod.add_wrapped(wrap_pyfunction!($name))?;
-    };
-}
-
 macro_rules! _create_pyfunc_with_x_with_ratio {
     ($name:ident, $resample_mod:ident, $resample_fn:ident, $type_x:ty, $type_y:ty, $mod:ident) => {
         // Create the Python function
@@ -157,28 +97,6 @@ macro_rules! _create_pyfunc_with_x_with_ratio {
             let x = x.as_slice().unwrap();
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(x, y, n_out, ratio);
-            sampled_indices.into_pyarray(py)
-        }
-        // Add the function to the module
-        $mod.add_wrapped(wrap_pyfunction!($name))?;
-    };
-}
-
-macro_rules! _create_pyfunc_with_x_with_ratio_multithreaded {
-    ($name:ident, $resample_mod:ident, $resample_fn:ident, $type_x:ty, $type_y:ty, $mod:ident) => {
-        // Create the Python function
-        #[pyfunction]
-        fn $name<'py>(
-            py: Python<'py>,
-            x: PyReadonlyArray1<$type_x>,
-            y: PyReadonlyArray1<$type_y>,
-            n_out: usize,
-            ratio: usize,
-            n_threads: usize,
-        ) -> &'py PyArray1<usize> {
-            let x = x.as_slice().unwrap();
-            let y = y.as_slice().unwrap();
-            let sampled_indices = $resample_mod::$resample_fn(x, y, n_out, ratio, n_threads);
             sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
@@ -234,14 +152,6 @@ macro_rules! create_pyfuncs_without_x {
             $mod
         );
     };
-    (@threaded $resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_without_x_helper!(
-            _create_pyfunc_without_x_multithreaded,
-            $resample_mod,
-            $resample_fn,
-            $mod
-        );
-    };
 }
 
 macro_rules! create_pyfuncs_without_x_with_ratio {
@@ -249,14 +159,6 @@ macro_rules! create_pyfuncs_without_x_with_ratio {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
         _create_pyfuncs_without_x_helper!(
             _create_pyfunc_without_x_with_ratio,
-            $resample_mod,
-            $resample_fn,
-            $mod
-        );
-    };
-    (@threaded $resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_without_x_helper!(
-            _create_pyfunc_without_x_with_ratio_multithreaded,
             $resample_mod,
             $resample_fn,
             $mod
@@ -275,14 +177,6 @@ macro_rules! create_pyfuncs_with_x {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
         _create_pyfuncs_with_x_helper!(_create_pyfunc_with_x, $resample_mod, $resample_fn, $mod);
     };
-    (@threaded $resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_with_x_helper!(
-            _create_pyfunc_with_x_multithreaded,
-            $resample_mod,
-            $resample_fn,
-            $mod
-        );
-    };
 }
 
 macro_rules! create_pyfuncs_with_x_with_ratio {
@@ -290,14 +184,6 @@ macro_rules! create_pyfuncs_with_x_with_ratio {
     ($resample_mod:ident, $resample_fn:ident, $mod:ident) => {
         _create_pyfuncs_with_x_helper!(
             _create_pyfunc_with_x_with_ratio,
-            $resample_mod,
-            $resample_fn,
-            $mod
-        );
-    };
-    (@threaded $resample_mod:ident, $resample_fn:ident, $mod:ident) => {
-        _create_pyfuncs_with_x_helper!(
-            _create_pyfunc_with_x_with_ratio_multithreaded,
             $resample_mod,
             $resample_fn,
             $mod
@@ -332,12 +218,12 @@ fn minmax(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     // ----- WITHOUT X
     {
-        create_pyfuncs_without_x!(@threaded minmax_mod, min_max_without_x_parallel, parallel_mod);
+        create_pyfuncs_without_x!(minmax_mod, min_max_without_x_parallel, parallel_mod);
     }
 
     // ----- WITH X
     {
-        create_pyfuncs_with_x!(@threaded minmax_mod, min_max_with_x_parallel, parallel_mod);
+        create_pyfuncs_with_x!(minmax_mod, min_max_with_x_parallel, parallel_mod);
     }
 
     // Add the sub modules to the module
@@ -374,12 +260,12 @@ fn m4(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // ----- WITHOUT X
     {
-        create_pyfuncs_without_x!(@threaded m4_mod, m4_without_x_parallel, parallel_mod);
+        create_pyfuncs_without_x!(m4_mod, m4_without_x_parallel, parallel_mod);
     }
 
     // ----- WITH X
     {
-        create_pyfuncs_with_x!(@threaded m4_mod, m4_with_x_parallel, parallel_mod);
+        create_pyfuncs_with_x!(m4_mod, m4_with_x_parallel, parallel_mod);
     }
 
     // Add the sub modules to the module
@@ -444,7 +330,7 @@ fn minmaxlttb(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // ----- WITHOUT X
     {
-        create_pyfuncs_without_x_with_ratio!(@threaded
+        create_pyfuncs_without_x_with_ratio!(
             minmaxlttb_mod,
             minmaxlttb_without_x_parallel,
             parallel_mod
@@ -453,11 +339,7 @@ fn minmaxlttb(_py: Python, m: &PyModule) -> PyResult<()> {
 
     // ----- WITH X
     {
-        create_pyfuncs_with_x_with_ratio!(@threaded
-            minmaxlttb_mod,
-            minmaxlttb_with_x_parallel,
-            parallel_mod
-        );
+        create_pyfuncs_with_x_with_ratio!(minmaxlttb_mod, minmaxlttb_with_x_parallel, parallel_mod);
     }
 
     // Add the submodules to the module

--- a/tests/benchmarks/test_downsamplers.py
+++ b/tests/benchmarks/test_downsamplers.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 
@@ -14,10 +12,6 @@ from tsdownsample import (
 NB_SAMPLES = ["100,000", "1,000,000"]
 N_OUT = ["100", "1,000", "5,000"]
 Y_DTYPES = [np.float32, np.float64] + [np.int32, np.int64]
-
-
-def _parallel_to_n_threads(parallel):
-    return 0 if not parallel else os.cpu_count()
 
 
 # --------------------------------------------------------------------------- #
@@ -35,11 +29,10 @@ def test_minmax_no_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = MinMaxDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, y, n_out=n_out, parallel=parallel)
 
 
 @pytest.mark.benchmark(group="minmax")
@@ -52,12 +45,11 @@ def test_minmax_with_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = MinMaxDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     x = np.arange(n_samples)
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, x, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, x, y, n_out=n_out, parallel=parallel)
 
 
 # --------------------------------------------------------------------------- #
@@ -75,11 +67,10 @@ def test_m4_no_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = M4Downsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, y, n_out=n_out, parallel=parallel)
 
 
 @pytest.mark.benchmark(group="m4")
@@ -92,12 +83,11 @@ def test_m4_with_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = M4Downsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     x = np.arange(n_samples)
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, x, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, x, y, n_out=n_out, parallel=parallel)
 
 
 # --------------------------------------------------------------------------- #
@@ -115,11 +105,10 @@ def test_lttb_no_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = LTTBDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, y, n_out=n_out, parallel=parallel)
 
 
 @pytest.mark.benchmark(group="lttb")
@@ -132,12 +121,11 @@ def test_lttb_with_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = LTTBDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     x = np.arange(n_samples)
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, x, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, x, y, n_out=n_out, parallel=parallel)
 
 
 # --------------------------------------------------------------------------- #
@@ -155,11 +143,10 @@ def test_minmaxlttb_no_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = MinMaxLTTBDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, y, n_out=n_out, parallel=parallel)
 
 
 @pytest.mark.benchmark(group="minmaxlttb")
@@ -172,12 +159,11 @@ def test_minmaxlttb_with_x(benchmark, n_samples, n_out, dtype, parallel):
     downsampler = MinMaxLTTBDownsampler()
     n_samples = int(n_samples.replace(",", ""))
     n_out = int(n_out.replace(",", ""))
-    n_threads = _parallel_to_n_threads(parallel)
 
     x = np.arange(n_samples)
     y = np.random.randn(n_samples).astype(dtype)
 
-    benchmark(downsampler.downsample, x, y, n_out=n_out, n_threads=n_threads)
+    benchmark(downsampler.downsample, x, y, n_out=n_out, parallel=parallel)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -89,7 +89,7 @@ def test_parallel_downsampling(downsampler: AbstractDownsampler):
     """Test parallel downsampling."""
     arr = np.random.randn(10_000).astype(np.float32)
     s_downsampled = downsampler.downsample(arr, n_out=100)
-    s_downsampled_p = downsampler.downsample(arr, n_out=100, n_threads=2)
+    s_downsampled_p = downsampler.downsample(arr, n_out=100, parallel=True)
     assert np.all(s_downsampled == s_downsampled_p)
 
 
@@ -99,7 +99,7 @@ def test_parallel_downsampling_with_x(downsampler: AbstractDownsampler):
     arr = np.random.randn(10_001).astype(np.float32)  # 10_001 to test edge case
     idx = np.arange(len(arr))
     s_downsampled = downsampler.downsample(idx, arr, n_out=100)
-    s_downsampled_p = downsampler.downsample(idx, arr, n_out=100, n_threads=2)
+    s_downsampled_p = downsampler.downsample(idx, arr, n_out=100, parallel=True)
     assert np.all(s_downsampled == s_downsampled_p)
 
 
@@ -170,7 +170,7 @@ def test_downsampling_no_out_of_bounds_different_dtypes(
     for dtype in supported_dtypes_y:
         arr = arr_orig.astype(dtype)
         s_downsampled = downsampler.downsample(arr, n_out=76)
-        s_downsampled_p = downsampler.downsample(arr, n_out=76, n_threads=2)
+        s_downsampled_p = downsampler.downsample(arr, n_out=76, parallel=True)
         assert np.all(s_downsampled == s_downsampled_p)
         if dtype is not np.bool_:
             res += [s_downsampled]
@@ -191,7 +191,7 @@ def test_downsampling_no_out_of_bounds_different_dtypes_with_x(
         for dtype_y in supported_dtypes_y:
             arr = arr_orig.astype(dtype_y)
             s_downsampled = downsampler.downsample(idx, arr, n_out=76)
-            s_downsampled_p = downsampler.downsample(idx, arr, n_out=76, n_threads=2)
+            s_downsampled_p = downsampler.downsample(idx, arr, n_out=76, parallel=True)
             assert np.all(s_downsampled == s_downsampled_p)
             if dtype_y is not np.bool_:
                 res += [s_downsampled]
@@ -248,25 +248,25 @@ def test_error_invalid_args():
     arr = np.random.randint(0, 100, size=10_000)
     # No args
     with pytest.raises(ValueError) as e_msg:
-        MinMaxDownsampler().downsample(n_out=100, n_threads=2)
+        MinMaxDownsampler().downsample(n_out=100, parallel=True)
     assert "takes 1 or 2 positional arguments" in str(e_msg.value)
     # Too many args
     with pytest.raises(ValueError) as e_msg:
-        MinMaxDownsampler().downsample(arr, arr, arr, n_out=100, n_threads=2)
+        MinMaxDownsampler().downsample(arr, arr, arr, n_out=100, parallel=True)
     assert "takes 1 or 2 positional arguments" in str(e_msg.value)
     # Invalid y
     with pytest.raises(ValueError) as e_msg:
-        MinMaxDownsampler().downsample(arr.reshape(5, 2_000), n_out=100, n_threads=2)
+        MinMaxDownsampler().downsample(arr.reshape(5, 2_000), n_out=100, parallel=True)
     assert "y must be 1D" in str(e_msg.value)
     # Invalid x
     with pytest.raises(ValueError) as e_msg:
         MinMaxDownsampler().downsample(
-            arr.reshape(5, 2_000), arr, n_out=100, n_threads=2
+            arr.reshape(5, 2_000), arr, n_out=100, parallel=True
         )
     assert "x must be 1D" in str(e_msg.value)
     # Invalid x and y (different length)
     with pytest.raises(ValueError) as e_msg:
-        MinMaxDownsampler().downsample(arr, arr[:-1], n_out=100, n_threads=2)
+        MinMaxDownsampler().downsample(arr, arr[:-1], n_out=100, parallel=True)
     assert "x and y must have the same length" in str(e_msg.value)
 
 

--- a/tsdownsample/__init__.py
+++ b/tsdownsample/__init__.py
@@ -8,7 +8,7 @@ from .downsamplers import (
     MinMaxLTTBDownsampler,
 )
 
-__version__ = "0.1.3rc1"
+__version__ = "0.1.3rc2"
 __author__ = "Jeroen Van Der Donckt"
 
 __all__ = [

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -45,11 +45,11 @@ class MinMaxLTTBDownsampler(AbstractRustDownsampler):
         return _tsdownsample_rs.minmaxlttb
 
     def downsample(
-        self, *args, n_out: int, minmax_ratio: int = 4, n_threads: int = 1, **_
+        self, *args, n_out: int, minmax_ratio: int = 4, parallel: bool = False, **_
     ):
         assert minmax_ratio > 0, "minmax_ratio must be greater than 0"
         return super().downsample(
-            *args, n_out=n_out, n_threads=n_threads, ratio=minmax_ratio
+            *args, n_out=n_out, parallel=parallel, ratio=minmax_ratio
         )
 
 


### PR DESCRIPTION
Decided to remove the `n_threads` argument and go back to the `parallel` argument, as there is a considerable overhead when creating a new Threadpool.
Instead, users can control the number of threads by setting the `TSDOWNSAMPLE_MAX_THREADS` env variable.