### PR TITLE
Add nightly feature

### DIFF
--- a/downsample_rs/Cargo.toml
+++ b/downsample_rs/Cargo.toml
@@ -8,11 +8,15 @@ license = "MIT"
 
 [dependencies]
 # TODO: perhaps use polars?
-argminmax = { version = "0.6.1", features = ["half"] }
+argminmax = { version = "0.6.1", features = ["float", "half"], default-features = false }
 half = { version = "2.3.1", default-features = false , features=["num-traits"], optional = true}
 num-traits = { version = "0.2.17", default-features = false }
 once_cell = "1"
 rayon = { version = "1.8.0", default-features = false }
+
+[features]
+default = ["nightly"]
+nightly = ["argminmax/nightly_simd"]
 
 [dev-dependencies]
 rstest = { version = "0.18.2", default-features = false }


### PR DESCRIPTION
Currently downsample_rs cannot be built with stable compiler, because `nightly_simd` is enabled by default for `argminmax`. 
I've added `nightly` feature (which is enabled by default) which activates `nightly_simd`, so this crate can be compiled with stable with `default-features=false` 

(yes, I really need that :) )