### PR TITLE
fix: prune nan idxs in output when omitting nans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,10 @@ module-name = "tsdownsample._rust._tsdownsample_rs" # The path to place the comp
 
 # Linting
 [tool.ruff]
-select = ["E", "F", "I"]
 line-length = 88
-extend-select = ["Q"]
-ignore = ["E402", "F403"]
+lint.select = ["E", "F", "I"]
+lint.extend-select = ["Q"]
+lint.ignore = ["E402", "F403"]
 
 # Formatting
 [tool.black]


### PR DESCRIPTION
closes #73 

This PR
- removes nan idxs when non NaN downsamplers (i.e., policy = omit NaN - such as `MinMaxDownsampler`)
- nothing is changed for Nan downsamplers (i.e., policy = return nan - such as `NaNMinMaxDownsampler`)