### PR TITLE
:muscle: add FPCS downsampling algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,12 @@ all: lint mypy test
 
 .PHONY: clean
 clean:
-	rm -rf `find . -name __pycache__`
-	rm -f `find . -type f -name '*.py[co]' `
-	rm -f `find . -type f -name '*~' `
-	rm -f `find . -type f -name '.*~' `
-	rm -f `find . -type f -name '*.cpython-*' `
+	# TODO -> this kinda wipes a lot of stuff in the python environment, maybe we should be more specific
+	rm -rf `find . -name __pycache__ -not -path "./.venv/*"`
+	rm -f `find . -type f -name '*.py[co]' -not -path "./.venv/*"`
+	rm -f `find . -type f -name '*~' -not -path "./.venv/*"`
+	rm -f `find . -type f -name '.*~' -not -path "./.venv/*"`
+	rm -f `find . -type f -name '*.cpython-*' -not -path "./.venv/*"`
 	rm -rf dist
 	rm -rf build
 	rm -rf target

--- a/downsample_rs/Cargo.toml
+++ b/downsample_rs/Cargo.toml
@@ -9,7 +9,9 @@ license = "MIT"
 [dependencies]
 # TODO: perhaps use polars?
 argminmax = { version = "0.6.1", features = ["half"] }
-half = { version = "2.3.1", default-features = false , features=["num-traits"], optional = true}
+half = { version = "2.3.1", default-features = false, features = [
+    "num-traits",
+], optional = true }
 num-traits = { version = "0.2.17", default-features = false }
 once_cell = "1"
 rayon = { version = "1.8.0", default-features = false }
@@ -34,4 +36,8 @@ harness = false
 
 [[bench]]
 name = "bench_minmaxlttb"
+harness = false
+
+[[bench]]
+name = "bench_fpcs"
 harness = false

--- a/downsample_rs/benches/bench_fpcs.rs
+++ b/downsample_rs/benches/bench_fpcs.rs
@@ -1,0 +1,92 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use dev_utils::{config, utils};
+use downsample_rs::fpcs as fpcs_mod;
+
+fn fpcs_f32_random_array_long(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_LONG;
+    let y = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
+    let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
+
+    // Non parallel
+    // --- without x
+    c.bench_function("fpcs_vanilla_f32", |b| {
+        b.iter(|| fpcs_mod::vanilla_fpcs_without_x(black_box(y.as_slice()), black_box(2_000)))
+    });
+    c.bench_function("fpcs_mm_f32", |b| {
+        b.iter(|| fpcs_mod::fpcs_without_x(black_box(y.as_slice()), black_box(2_000)))
+    });
+    // --- with x
+    c.bench_function("fpcs_mm_f32_x", |b| {
+        b.iter(|| {
+            fpcs_mod::fpcs_with_x(
+                black_box(x.as_slice()),
+                black_box(y.as_slice()),
+                black_box(2_000),
+            )
+        })
+    });
+
+    // Parallel
+    // --- without x
+    c.bench_function("fpcs_mm_f32_par", |b| {
+        b.iter(|| fpcs_mod::fpcs_without_x_parallel(black_box(y.as_slice()), black_box(2_000)))
+    });
+    // --- with x
+    c.bench_function("fpcs_mm_f32_x_par", |b| {
+        b.iter(|| {
+            fpcs_mod::fpcs_with_x_parallel(
+                black_box(x.as_slice()),
+                black_box(y.as_slice()),
+                black_box(2_000),
+            )
+        })
+    });
+}
+
+fn fpcs_f32_random_array_50m(c: &mut Criterion) {
+    let n = 50_000_000;
+    let y = utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
+    let x = (0..n).map(|i| i as i32).collect::<Vec<i32>>();
+
+    // Non parallel
+    // --- without x
+    c.bench_function("fpcs_vanilla_50M_f32", |b| {
+        b.iter(|| fpcs_mod::vanilla_fpcs_without_x(black_box(y.as_slice()), black_box(2_000)))
+    });
+    c.bench_function("fpcs_mm_50M_f32", |b| {
+        b.iter(|| fpcs_mod::fpcs_without_x(black_box(y.as_slice()), black_box(2_000)))
+    });
+    // --- with x
+    c.bench_function("fpcs_mm_50M_f32_x", |b| {
+        b.iter(|| {
+            fpcs_mod::fpcs_with_x(
+                black_box(x.as_slice()),
+                black_box(y.as_slice()),
+                black_box(2_000),
+            )
+        })
+    });
+    // Parallel
+    // --- without x
+    c.bench_function("fpcs_mm_50M_f32_par", |b| {
+        b.iter(|| fpcs_mod::fpcs_without_x_parallel(black_box(y.as_slice()), black_box(2_000)))
+    });
+    // --- with x
+    c.bench_function("fpcs_mm_50M_f32_x_par", |b| {
+        b.iter(|| {
+            fpcs_mod::fpcs_with_x_parallel(
+                black_box(x.as_slice()),
+                black_box(y.as_slice()),
+                black_box(2_000),
+            )
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    //
+    fpcs_f32_random_array_long,
+    fpcs_f32_random_array_50m,
+);
+criterion_main!(benches);

--- a/downsample_rs/src/fpcs.rs
+++ b/downsample_rs/src/fpcs.rs
@@ -1,0 +1,496 @@
+// use rayon::iter::IndexedParallelIterator;
+use rayon::prelude::*;
+
+use argminmax::{ArgMinMax, NaNArgMinMax};
+use num_traits::{AsPrimitive, FromPrimitive};
+
+// use crate::minmax;
+
+use super::searchsorted::{
+    get_equidistant_bin_idx_iterator, get_equidistant_bin_idx_iterator_parallel,
+};
+use super::types::Num;
+use super::POOL;
+
+// ----------------------------------- Helper datastructures ------------------------------------
+struct Point<Ty> {
+    x: usize,
+    y: Ty,
+}
+
+impl<Ty> Point<Ty> {
+    fn update(&mut self, x: usize, y: Ty) {
+        self.x = x;
+        self.y = y;
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum Flag {
+    Min,
+    Max,
+    None,
+}
+
+// ----------------------------------- NON-PARALLEL ------------------------------------
+// ----------- WITH X
+macro_rules! fpcs_with_x {
+    ($func_name:ident, $trait:ident, $f_fpcs:expr) => {
+        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            Tx: Num + AsPrimitive<f64> + FromPrimitive,
+            Ty: Num + AsPrimitive<f64>,
+        {
+            let bin_idx_iterator = get_equidistant_bin_idx_iterator(x, n_out - 2);
+            fpcs_generic(y, bin_idx_iterator, n_out, $f_fpcs)
+        }
+    };
+}
+
+fpcs_with_x!(fpcs_with_x, ArgMinMax, |arr| arr.argminmax());
+fpcs_with_x!(fpcs_with_x_nan, NaNArgMinMax, |arr| arr.nanargminmax());
+
+// ----------- WITHOUT X
+macro_rules! fpcs_without_x {
+    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
+        pub fn $func_name<T: Copy + PartialOrd>(arr: &[T], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [T]: $trait,
+        {
+            fpcs_generic_without_x(arr, n_out, $f_argminmax)
+        }
+    };
+}
+
+fpcs_without_x!(fpcs_without_x, ArgMinMax, |arr| arr.argminmax());
+fpcs_without_x!(fpcs_without_x_nan, NaNArgMinMax, |arr| arr.nanargminmax());
+
+// ------------------------------------- PARALLEL --------------------------------------
+// ----------- WITH X
+macro_rules! fpcs_with_x_parallel {
+    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
+        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            Tx: Num + AsPrimitive<f64> + FromPrimitive + Send + Sync,
+            Ty: Num + AsPrimitive<f64> + Send + Sync,
+        {
+            // collect the parrallel iterator to a vector
+            let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out - 2);
+            fpcs_generic_parallel(y, bin_idx_iterator, n_out, $f_argminmax)
+        }
+    };
+}
+
+fpcs_with_x_parallel!(fpcs_with_x_parallel, ArgMinMax, |arr| arr.argminmax());
+fpcs_with_x_parallel!(fpcs_with_x_parallel_nan, NaNArgMinMax, |arr| arr
+    .nanargminmax());
+
+// ----------- WITHOUT X
+macro_rules! fpcs_without_x_parallel {
+    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
+        pub fn $func_name<Ty: Copy + PartialOrd + Send + Sync>(
+            arr: &[Ty],
+            n_out: usize,
+        ) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            // Ty: Num + AsPrimitive<f64> + Send + Sync,
+        {
+            fpcs_generic_without_x_parallel(arr, n_out, $f_argminmax)
+        }
+    };
+}
+
+fpcs_without_x_parallel!(fpcs_without_x_parallel, ArgMinMax, |arr| arr.argminmax());
+fpcs_without_x_parallel!(fpcs_without_x_parallel_nan, NaNArgMinMax, |arr| arr
+    .nanargminmax());
+
+// ----------- WITHOUT X
+
+// ------------------------------------- GENERICS --------------------------------------
+// move the inner loop to a separate function to reduce code duplication
+fn fpcs_inner_loop<Ty: PartialOrd + Copy>(
+    y: &[Ty],
+    min_idx: usize,
+    max_idx: usize,
+    min_point: &mut Point<Ty>,
+    max_point: &mut Point<Ty>,
+    potential_point: &mut Point<Ty>,
+    previous_min_flag: &mut Flag,
+    sampled_indices: &mut Vec<usize>,
+) {
+    // only update when the min/max is more extreme than the current min/max
+    if y[max_idx] > max_point.y {
+        max_point.update(max_idx, y[max_idx]);
+    }
+    if y[min_idx] < min_point.y {
+        min_point.update(min_idx, y[min_idx]);
+    }
+
+    // if the min is to the left of the max
+    if min_point.x < max_point.x {
+        // if the min was selected in the previos bin
+        if *previous_min_flag == Flag::Min && min_point.x != potential_point.x {
+            sampled_indices.push(potential_point.x);
+        }
+        sampled_indices.push(min_point.x);
+
+        potential_point.update(max_point.x, max_point.y);
+        min_point.update(max_point.x, max_point.y);
+        *previous_min_flag = Flag::Min;
+    } else {
+        if *previous_min_flag == Flag::Max && max_point.x != potential_point.x {
+            sampled_indices.push(potential_point.x as usize);
+        }
+        sampled_indices.push(max_point.x as usize);
+
+        potential_point.update(min_point.x, min_point.y);
+        max_point.update(min_point.x, min_point.y);
+        *previous_min_flag = Flag::Max;
+    }
+}
+
+// ----------- WITH X
+#[inline(always)]
+pub(crate) fn fpcs_generic<T: PartialOrd + Copy>(
+    y: &[T],
+    bin_idx_iterator: impl Iterator<Item = Option<(usize, usize)>>,
+    n_out: usize,
+    f_argminmax: fn(&[T]) -> (usize, usize),
+) -> Vec<usize> {
+    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
+
+    let mut previous_min_flag: Flag = Flag::None;
+    let mut potential_point: Point<T> = Point { x: 0, y: y[0] };
+    let mut max_point: Point<T> = Point { x: 0, y: y[0] };
+    let mut min_point: Point<T> = Point { x: 0, y: y[0] };
+
+    bin_idx_iterator.for_each(|bin| {
+        if let Some((start, end)) = bin {
+            if end <= start + 2 {
+                // if the bin has <= 2 elements, we just add them all
+                for i in start..end {
+                    sampled_indices.push(i);
+                }
+            } else {
+                // if the bin has at least two elements, we find the min and max
+                let (min_idx, max_idx) = f_argminmax(&y[start..end]);
+
+                fpcs_inner_loop(
+                    y,
+                    min_idx,
+                    max_idx,
+                    &mut min_point,
+                    &mut max_point,
+                    &mut potential_point,
+                    &mut previous_min_flag,
+                    &mut sampled_indices,
+                );
+            }
+        }
+    });
+    // add the last sample
+    sampled_indices.push(y.len() as usize - 1);
+    sampled_indices
+}
+
+#[inline(always)]
+pub(crate) fn fpcs_generic_parallel<T: PartialOrd + Copy + Send + Sync>(
+    arr: &[T],
+    bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = Option<(usize, usize)>>>,
+    n_out: usize,
+    f_argminmax: fn(&[T]) -> (usize, usize),
+) -> Vec<usize> {
+    // Pre-allocate the vector with the right capacity - this will store min-max
+    // from each bin to be used in the FPCS algorithm
+    let mut minmax_idxs: Vec<usize> = Vec::with_capacity((n_out - 2) * 2);
+
+    POOL.install(|| {
+        // Process bins in parallel to find min-max index pairs from each bin
+        // Each result contains (bin_position, [min_idx, max_idx]) where:
+        // - bin_position ensures results maintain correct order when collected
+        // - min_idx is the index of minimum value in the bin
+        // - max_idx is the index of maximum value in the bin
+        let results: Vec<(usize, [usize; 2])> = bin_idx_iterator
+            .enumerate()
+            .flat_map(|(bin_index, bin_idx_iterator)| {
+                bin_idx_iterator
+                    .filter_map(|bin| {
+                        bin.and_then(|(start, end)| {
+                            match end - start {
+                                0 => None, // Empty bin
+                                1 => {
+                                    // Single element - add it to the result
+                                    Some((bin_index * 2, [start, start]))
+                                }
+                                2 => {
+                                    // Two elements - determine min and max
+                                    let (min_idx, max_idx) = if arr[start] <= arr[start + 1] {
+                                        (start, start + 1)
+                                    } else {
+                                        (start + 1, start)
+                                    };
+                                    Some((bin_index * 2, [min_idx, max_idx]))
+                                }
+                                _ => {
+                                    // Larger bins - find min and max
+                                    let (min_idx, max_idx) = f_argminmax(&arr[start..end]);
+                                    Some((bin_index * 2, [min_idx + start, max_idx + start]))
+                                }
+                            }
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        // Only process results if we have any valid bins
+        if !results.is_empty() {
+            // Ensure we have enough capacity to avoid reallocations
+            minmax_idxs.reserve(results.len() * 2);
+
+            // Populate minmax_idxs with alternating min-max indices
+            // These will be processed in pairs by fpcs_inner_loop
+            for (_, [min_idx, max_idx]) in results {
+                minmax_idxs.push(min_idx);
+                minmax_idxs.push(max_idx);
+            }
+        }
+    });
+
+    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
+
+    let mut previous_min_flag: Flag = Flag::None;
+    let mut potential_point: Point<T> = Point { x: 0, y: arr[0] };
+    let mut max_point: Point<T> = Point { x: 0, y: arr[0] };
+    let mut min_point: Point<T> = Point { x: 0, y: arr[0] };
+
+    // Prepend first and last point
+    sampled_indices.push(0);
+
+    // Process the min/max pairs
+    for chunk in minmax_idxs.chunks(2) {
+        if chunk.len() == 2 {
+            let min_idx = chunk[0];
+            let max_idx = chunk[1];
+
+            fpcs_inner_loop(
+                arr,
+                min_idx,
+                max_idx,
+                &mut min_point,
+                &mut max_point,
+                &mut potential_point,
+                &mut previous_min_flag,
+                &mut sampled_indices,
+            );
+        } else if chunk.len() == 1 {
+            // Handle any remaining single element
+            sampled_indices.push(chunk[0]);
+        }
+    }
+
+    // add the last sample
+    sampled_indices.push(arr.len() as usize - 1);
+    sampled_indices
+}
+
+// ----------- WITHOUT X
+#[inline(always)]
+pub(crate) fn fpcs_generic_without_x<Ty: PartialOrd + Copy>(
+    y: &[Ty],
+    n_out: usize, // handle n_out behavior on a higher level
+    f_argminmax: fn(&[Ty]) -> (usize, usize),
+) -> Vec<usize> {
+    if n_out >= y.len() {
+        return (0..y.len()).collect::<Vec<usize>>();
+    }
+    assert!(n_out >= 3); // avoid division by 0
+                         // let f_argminmax = y.argminmax();
+
+    let block_size: f64 = y.len() as f64 / (n_out - 2) as f64;
+
+    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
+
+    let mut previous_min_flag: Flag = Flag::None;
+    let mut potential_point: Point<Ty> = Point { x: 0, y: y[0] };
+    let mut max_point: Point<Ty> = Point { x: 0, y: y[0] };
+    let mut min_point: Point<Ty> = Point { x: 0, y: y[0] };
+
+    let mut lower: usize = 1;
+    let mut upper: usize = (block_size as usize) + 1;
+    while upper < y.len() {
+        let (mut min_idx, mut max_idx) = f_argminmax(&y[lower..upper]);
+        min_idx += lower;
+        max_idx += lower;
+
+        fpcs_inner_loop(
+            y,
+            min_idx,
+            max_idx,
+            &mut min_point,
+            &mut max_point,
+            &mut potential_point,
+            &mut previous_min_flag,
+            &mut sampled_indices,
+        );
+
+        lower = upper;
+        upper = (upper as f64 + block_size) as usize;
+    }
+
+    // add the last sample
+    sampled_indices.push(y.len() as usize - 1);
+    sampled_indices
+}
+
+#[inline(always)]
+pub(crate) fn fpcs_generic_without_x_parallel<T: PartialOrd + Copy + Send + Sync>(
+    arr: &[T],
+    n_out: usize,
+    f_argminmax: fn(&[T]) -> (usize, usize),
+) -> Vec<usize> {
+    // --------- 1. parallelize the min-max search
+    // arr.len() -1 is used to match the delta of a range-index (0..arr.len()-1)
+    let block_size: f64 = (arr.len() - 1) as f64 / (n_out - 2) as f64;
+
+    // let mut minmax_idxs: Vec<usize> = Vec::with_capacity((n_out - 2) * 2);
+    let mut minmax_idxs: Vec<usize> = vec![0; (n_out - 2) * 2];
+
+    POOL.install(|| {
+        minmax_idxs
+            .par_chunks_exact_mut(2)
+            .for_each(|min_max_index_chunk| {
+                let i: f64 = unsafe { *min_max_index_chunk.get_unchecked(0) >> 1 } as f64;
+                let start_idx: usize = (block_size * i) as usize + (i != 0.0) as usize;
+                let end_idx: usize = (block_size * (i + 1.0)) as usize + 1;
+
+                let (min_index, max_index) = f_argminmax(&arr[start_idx..end_idx]);
+
+                // Add the indexes in min-max order
+                min_max_index_chunk[0] = min_index + start_idx;
+                min_max_index_chunk[1] = max_index + start_idx;
+            })
+    });
+
+    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
+
+    let mut previous_min_flag: Flag = Flag::None;
+    let mut potential_point: Point<T> = Point { x: 0, y: arr[0] };
+    let mut max_point: Point<T> = Point { x: 0, y: arr[0] };
+    let mut min_point: Point<T> = Point { x: 0, y: arr[0] };
+
+    // Prepend first and last point
+    sampled_indices.push(0);
+
+    // Process the min/max pairs
+    for chunk in minmax_idxs.chunks(2) {
+        if chunk.len() == 2 {
+            let min_idx = chunk[0];
+            let max_idx = chunk[1];
+
+            fpcs_inner_loop(
+                arr,
+                min_idx,
+                max_idx,
+                &mut min_point,
+                &mut max_point,
+                &mut potential_point,
+                &mut previous_min_flag,
+                &mut sampled_indices,
+            );
+        } else if chunk.len() == 1 {
+            // Handle any remaining single element
+            sampled_indices.push(chunk[0]);
+        }
+    }
+
+    // add the last sample
+    sampled_indices.push(arr.len() as usize - 1);
+    sampled_indices
+}
+
+pub fn vanilla_fpcs_without_x<Ty: Num + std::cmp::PartialOrd + Copy>(
+    y: &[Ty],
+    n_out: usize, // NOTE: there will be between [n_out, 2*n_out] output points
+) -> Vec<usize> {
+    if n_out >= y.len() {
+        return (0..y.len()).collect::<Vec<usize>>();
+    }
+    assert!(n_out >= 3); // avoid division by 0
+
+    // TODO -> we don't know the size of the output vector
+    // TODO -> make this more concise in a future version
+    let mut retain_idxs: Vec<usize> = Vec::with_capacity(n_out * 2);
+
+    let mut meta_counter: u32 = 1;
+    // TODO -> check
+    let threshold: f64 = y.len() as f64 / (n_out - 2) as f64;
+    let mut previous_min_flag: Flag = Flag::None;
+    let mut potential_point: Point<Ty> = Point { x: 0, y: y[0] };
+    let mut max_point: Point<Ty> = Point { x: 0, y: y[0] };
+    let mut min_point: Point<Ty> = Point { x: 0, y: y[0] };
+
+    for idx in 1..y.len() {
+        let val = y[idx];
+
+        if val > max_point.y {
+            max_point.update(idx, val);
+        }
+        if val < min_point.y {
+            min_point.update(idx, val);
+        }
+
+        if (idx > ((meta_counter as f64) * threshold) as usize) || (idx == y.len() - 1) {
+            // edge case -> previous flag is None
+            meta_counter += 1;
+
+            // if the min is to the left of the max
+            if min_point.x < max_point.x {
+                // if the min was selected in the previos bin
+                if previous_min_flag == Flag::Min && min_point.x != potential_point.x {
+                    retain_idxs.push(potential_point.x as usize);
+                }
+                retain_idxs.push(min_point.x as usize);
+
+                potential_point.update(max_point.x, max_point.y);
+                min_point.update(max_point.x, max_point.y);
+                previous_min_flag = Flag::Min;
+            } else {
+                if previous_min_flag == Flag::Max && max_point.x != potential_point.x {
+                    retain_idxs.push(potential_point.x as usize);
+                }
+                retain_idxs.push(max_point.x as usize);
+
+                potential_point.update(min_point.x, min_point.y);
+                max_point.update(min_point.x, min_point.y);
+                previous_min_flag = Flag::Max;
+            }
+        }
+    }
+
+    // add the last sample
+    retain_idxs.push(y.len() as usize - 1);
+    return retain_idxs;
+}
+
+// --------------------------------------- TESTS ---------------------------------------
+#[cfg(test)]
+mod tests {
+    use dev_utils::utils;
+
+    use super::fpcs_without_x;
+
+    #[test]
+    fn test_fpcs_with_x() {
+        let x = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let y = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let n_out = 3;
+        // let sampled_indices = fpcs_without_x(&x, &y, n_out);
+        // TODO -> fix after we have a library
+        // assert eq(sampled_indices, vec![0, 9])
+        // utils::print_vec(&res);
+    }
+}

--- a/downsample_rs/src/fpcs.rs
+++ b/downsample_rs/src/fpcs.rs
@@ -1,18 +1,9 @@
-// use rayon::iter::IndexedParallelIterator;
-use rayon::prelude::*;
-
+use super::minmax;
+use super::types::Num;
 use argminmax::{ArgMinMax, NaNArgMinMax};
 use num_traits::{AsPrimitive, FromPrimitive};
 
-// use crate::minmax;
-
-use super::searchsorted::{
-    get_equidistant_bin_idx_iterator, get_equidistant_bin_idx_iterator_parallel,
-};
-use super::types::Num;
-use super::POOL;
-
-// ----------------------------------- Helper datastructures ------------------------------------
+// ------------------------------- Helper datastructures -------------------------------
 struct Point<Ty> {
     x: usize,
     y: Ty,
@@ -32,85 +23,8 @@ enum Flag {
     None,
 }
 
-// ----------------------------------- NON-PARALLEL ------------------------------------
-// ----------- WITH X
-macro_rules! fpcs_with_x {
-    ($func_name:ident, $trait:ident, $f_fpcs:expr) => {
-        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
-        where
-            for<'a> &'a [Ty]: $trait,
-            Tx: Num + AsPrimitive<f64> + FromPrimitive,
-            Ty: Num + AsPrimitive<f64>,
-        {
-            let bin_idx_iterator = get_equidistant_bin_idx_iterator(x, n_out - 2);
-            fpcs_generic(y, bin_idx_iterator, n_out, $f_fpcs)
-        }
-    };
-}
-
-fpcs_with_x!(fpcs_with_x, ArgMinMax, |arr| arr.argminmax());
-fpcs_with_x!(fpcs_with_x_nan, NaNArgMinMax, |arr| arr.nanargminmax());
-
-// ----------- WITHOUT X
-macro_rules! fpcs_without_x {
-    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
-        pub fn $func_name<T: Copy + PartialOrd>(arr: &[T], n_out: usize) -> Vec<usize>
-        where
-            for<'a> &'a [T]: $trait,
-        {
-            fpcs_generic_without_x(arr, n_out, $f_argminmax)
-        }
-    };
-}
-
-fpcs_without_x!(fpcs_without_x, ArgMinMax, |arr| arr.argminmax());
-fpcs_without_x!(fpcs_without_x_nan, NaNArgMinMax, |arr| arr.nanargminmax());
-
-// ------------------------------------- PARALLEL --------------------------------------
-// ----------- WITH X
-macro_rules! fpcs_with_x_parallel {
-    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
-        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
-        where
-            for<'a> &'a [Ty]: $trait,
-            Tx: Num + AsPrimitive<f64> + FromPrimitive + Send + Sync,
-            Ty: Num + AsPrimitive<f64> + Send + Sync,
-        {
-            // collect the parrallel iterator to a vector
-            let bin_idx_iterator = get_equidistant_bin_idx_iterator_parallel(x, n_out - 2);
-            fpcs_generic_parallel(y, bin_idx_iterator, n_out, $f_argminmax)
-        }
-    };
-}
-
-fpcs_with_x_parallel!(fpcs_with_x_parallel, ArgMinMax, |arr| arr.argminmax());
-fpcs_with_x_parallel!(fpcs_with_x_parallel_nan, NaNArgMinMax, |arr| arr
-    .nanargminmax());
-
-// ----------- WITHOUT X
-macro_rules! fpcs_without_x_parallel {
-    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
-        pub fn $func_name<Ty: Copy + PartialOrd + Send + Sync>(
-            arr: &[Ty],
-            n_out: usize,
-        ) -> Vec<usize>
-        where
-            for<'a> &'a [Ty]: $trait,
-            // Ty: Num + AsPrimitive<f64> + Send + Sync,
-        {
-            fpcs_generic_without_x_parallel(arr, n_out, $f_argminmax)
-        }
-    };
-}
-
-fpcs_without_x_parallel!(fpcs_without_x_parallel, ArgMinMax, |arr| arr.argminmax());
-fpcs_without_x_parallel!(fpcs_without_x_parallel_nan, NaNArgMinMax, |arr| arr
-    .nanargminmax());
-
-// ----------- WITHOUT X
-
-// ------------------------------------- GENERICS --------------------------------------
-// move the inner loop to a separate function to reduce code duplication
+// --------------------------------- helper functions ----------------------------------
+#[inline(always)]
 fn fpcs_inner_loop<Ty: PartialOrd + Copy>(
     y: &[Ty],
     min_idx: usize,
@@ -152,129 +66,33 @@ fn fpcs_inner_loop<Ty: PartialOrd + Copy>(
     }
 }
 
-// ----------- WITH X
 #[inline(always)]
-pub(crate) fn fpcs_generic<T: PartialOrd + Copy>(
-    y: &[T],
-    bin_idx_iterator: impl Iterator<Item = Option<(usize, usize)>>,
+fn fpcs_outer_loop<Ty: PartialOrd + Copy>(
+    arr: &[Ty],
+    minmax_idxs: Vec<usize>,
     n_out: usize,
-    f_argminmax: fn(&[T]) -> (usize, usize),
 ) -> Vec<usize> {
-    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
-
     let mut previous_min_flag: Flag = Flag::None;
-    let mut potential_point: Point<T> = Point { x: 0, y: y[0] };
-    let mut max_point: Point<T> = Point { x: 0, y: y[0] };
-    let mut min_point: Point<T> = Point { x: 0, y: y[0] };
-
-    bin_idx_iterator.for_each(|bin| {
-        if let Some((start, end)) = bin {
-            if end <= start + 2 {
-                // if the bin has <= 2 elements, we just add them all
-                for i in start..end {
-                    sampled_indices.push(i);
-                }
-            } else {
-                // if the bin has at least two elements, we find the min and max
-                let (min_idx, max_idx) = f_argminmax(&y[start..end]);
-
-                fpcs_inner_loop(
-                    y,
-                    min_idx,
-                    max_idx,
-                    &mut min_point,
-                    &mut max_point,
-                    &mut potential_point,
-                    &mut previous_min_flag,
-                    &mut sampled_indices,
-                );
-            }
-        }
-    });
-    // add the last sample
-    sampled_indices.push(y.len() as usize - 1);
-    sampled_indices
-}
-
-#[inline(always)]
-pub(crate) fn fpcs_generic_parallel<T: PartialOrd + Copy + Send + Sync>(
-    arr: &[T],
-    bin_idx_iterator: impl IndexedParallelIterator<Item = impl Iterator<Item = Option<(usize, usize)>>>,
-    n_out: usize,
-    f_argminmax: fn(&[T]) -> (usize, usize),
-) -> Vec<usize> {
-    // Pre-allocate the vector with the right capacity - this will store min-max
-    // from each bin to be used in the FPCS algorithm
-    let mut minmax_idxs: Vec<usize> = Vec::with_capacity((n_out - 2) * 2);
-
-    POOL.install(|| {
-        // Process bins in parallel to find min-max index pairs from each bin
-        // Each result contains (bin_position, [min_idx, max_idx]) where:
-        // - bin_position ensures results maintain correct order when collected
-        // - min_idx is the index of minimum value in the bin
-        // - max_idx is the index of maximum value in the bin
-        let results: Vec<(usize, [usize; 2])> = bin_idx_iterator
-            .enumerate()
-            .flat_map(|(bin_index, bin_idx_iterator)| {
-                bin_idx_iterator
-                    .filter_map(|bin| {
-                        bin.and_then(|(start, end)| {
-                            match end - start {
-                                0 => None, // Empty bin
-                                1 => {
-                                    // Single element - add it to the result
-                                    Some((bin_index * 2, [start, start]))
-                                }
-                                2 => {
-                                    // Two elements - determine min and max
-                                    let (min_idx, max_idx) = if arr[start] <= arr[start + 1] {
-                                        (start, start + 1)
-                                    } else {
-                                        (start + 1, start)
-                                    };
-                                    Some((bin_index * 2, [min_idx, max_idx]))
-                                }
-                                _ => {
-                                    // Larger bins - find min and max
-                                    let (min_idx, max_idx) = f_argminmax(&arr[start..end]);
-                                    Some((bin_index * 2, [min_idx + start, max_idx + start]))
-                                }
-                            }
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        // Only process results if we have any valid bins
-        if !results.is_empty() {
-            // Ensure we have enough capacity to avoid reallocations
-            minmax_idxs.reserve(results.len() * 2);
-
-            // Populate minmax_idxs with alternating min-max indices
-            // These will be processed in pairs by fpcs_inner_loop
-            for (_, [min_idx, max_idx]) in results {
-                minmax_idxs.push(min_idx);
-                minmax_idxs.push(max_idx);
-            }
-        }
-    });
+    let mut potential_point: Point<Ty> = Point { x: 0, y: arr[0] };
+    let mut max_point: Point<Ty> = Point { x: 0, y: arr[0] };
+    let mut min_point: Point<Ty> = Point { x: 0, y: arr[0] };
 
     let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
-
-    let mut previous_min_flag: Flag = Flag::None;
-    let mut potential_point: Point<T> = Point { x: 0, y: arr[0] };
-    let mut max_point: Point<T> = Point { x: 0, y: arr[0] };
-    let mut min_point: Point<T> = Point { x: 0, y: arr[0] };
-
-    // Prepend first and last point
+    // Prepend first point
     sampled_indices.push(0);
 
     // Process the min/max pairs
     for chunk in minmax_idxs.chunks(2) {
         if chunk.len() == 2 {
-            let min_idx = chunk[0];
-            let max_idx = chunk[1];
+            let mut min_idx = chunk[0];
+            let mut max_idx = chunk[1];
+
+            // NOTE: the minmax_idxs are not ordered!!
+            // So we need to check if the min is actually the min
+            if arr[min_idx] >= arr[max_idx] {
+                min_idx = chunk[1];
+                max_idx = chunk[0];
+            }
 
             fpcs_inner_loop(
                 arr,
@@ -295,122 +113,139 @@ pub(crate) fn fpcs_generic_parallel<T: PartialOrd + Copy + Send + Sync>(
     // add the last sample
     sampled_indices.push(arr.len() as usize - 1);
     sampled_indices
+}
+
+// -------------------------------------- MACROs ---------------------------------------
+// ----------------------------------- NON-PARALLEL ------------------------------------
+
+// ----------- WITH X
+
+macro_rules! fpcs_with_x {
+    ($func_name:ident, $trait:ident, $f_minmax:expr) => {
+        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            Tx: Num + FromPrimitive + AsPrimitive<f64>,
+            Ty: Copy + PartialOrd,
+        {
+            fpcs_generic(x, y, n_out, $f_minmax)
+        }
+    };
+}
+
+fpcs_with_x!(fpcs_with_x, ArgMinMax, minmax::min_max_with_x);
+fpcs_with_x!(fpcs_with_x_nan, NaNArgMinMax, minmax::min_max_with_x_nan);
+
+// ----------- WITHOUT X
+
+macro_rules! fpcs_without_x {
+    ($func_name:ident, $trait:path, $f_minmax:expr) => {
+        pub fn $func_name<T: Copy + PartialOrd>(arr: &[T], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [T]: $trait,
+        {
+            fpcs_generic_without_x(arr, n_out, $f_minmax)
+        }
+    };
+}
+
+fpcs_without_x!(fpcs_without_x, ArgMinMax, minmax::min_max_without_x);
+fpcs_without_x!(
+    fpcs_without_x_nan,
+    NaNArgMinMax,
+    minmax::min_max_without_x_nan
+);
+
+// ------------------------------------- PARALLEL --------------------------------------
+
+// ----------- WITH X
+
+macro_rules! fpcs_with_x_parallel {
+    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
+        pub fn $func_name<Tx, Ty>(x: &[Tx], y: &[Ty], n_out: usize) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
+            Ty: Num + Copy + PartialOrd + Send + Sync,
+        {
+            // collect the parrallel iterator to a vector
+            fpcs_generic(x, y, n_out, $f_argminmax)
+        }
+    };
+}
+
+fpcs_with_x_parallel!(
+    fpcs_with_x_parallel,
+    ArgMinMax,
+    minmax::min_max_with_x_parallel
+);
+fpcs_with_x_parallel!(
+    fpcs_with_x_parallel_nan,
+    NaNArgMinMax,
+    minmax::min_max_with_x_parallel_nan
+);
+
+// ----------- WITHOUT X
+
+macro_rules! fpcs_without_x_parallel {
+    ($func_name:ident, $trait:path, $f_argminmax:expr) => {
+        pub fn $func_name<Ty: Copy + PartialOrd + Send + Sync>(
+            arr: &[Ty],
+            n_out: usize,
+        ) -> Vec<usize>
+        where
+            for<'a> &'a [Ty]: $trait,
+            // Ty: Num + AsPrimitive<f64> + Send + Sync,
+        {
+            fpcs_generic_without_x(arr, n_out, $f_argminmax)
+        }
+    };
+}
+
+fpcs_without_x_parallel!(
+    fpcs_without_x_parallel,
+    ArgMinMax,
+    minmax::min_max_without_x_parallel
+);
+fpcs_without_x_parallel!(
+    fpcs_without_x_parallel_nan,
+    NaNArgMinMax,
+    minmax::min_max_without_x_parallel_nan
+);
+
+// ------------------------------------- GENERICS --------------------------------------
+
+// ----------- WITH X
+
+#[inline(always)]
+pub(crate) fn fpcs_generic<Tx: Num + AsPrimitive<f64>, Ty: PartialOrd + Copy>(
+    x: &[Tx],
+    y: &[Ty],
+    n_out: usize,
+    f_minmax: fn(&[Tx], &[Ty], usize) -> Vec<usize>,
+) -> Vec<usize> {
+    assert_eq!(x.len(), y.len());
+    let mut minmax_idxs = f_minmax(&x[1..(x.len() - 1)], &y[1..(x.len() - 1)], n_out * 2);
+    minmax_idxs.iter_mut().for_each(|elem| *elem += 1); // inplace + 1
+    return fpcs_outer_loop(y, minmax_idxs, n_out);
 }
 
 // ----------- WITHOUT X
-#[inline(always)]
-pub(crate) fn fpcs_generic_without_x<Ty: PartialOrd + Copy>(
-    y: &[Ty],
-    n_out: usize, // handle n_out behavior on a higher level
-    f_argminmax: fn(&[Ty]) -> (usize, usize),
-) -> Vec<usize> {
-    if n_out >= y.len() {
-        return (0..y.len()).collect::<Vec<usize>>();
-    }
-    assert!(n_out >= 3); // avoid division by 0
-                         // let f_argminmax = y.argminmax();
-
-    let block_size: f64 = y.len() as f64 / (n_out - 2) as f64;
-
-    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
-
-    let mut previous_min_flag: Flag = Flag::None;
-    let mut potential_point: Point<Ty> = Point { x: 0, y: y[0] };
-    let mut max_point: Point<Ty> = Point { x: 0, y: y[0] };
-    let mut min_point: Point<Ty> = Point { x: 0, y: y[0] };
-
-    let mut lower: usize = 1;
-    let mut upper: usize = (block_size as usize) + 1;
-    while upper < y.len() {
-        let (mut min_idx, mut max_idx) = f_argminmax(&y[lower..upper]);
-        min_idx += lower;
-        max_idx += lower;
-
-        fpcs_inner_loop(
-            y,
-            min_idx,
-            max_idx,
-            &mut min_point,
-            &mut max_point,
-            &mut potential_point,
-            &mut previous_min_flag,
-            &mut sampled_indices,
-        );
-
-        lower = upper;
-        upper = (upper as f64 + block_size) as usize;
-    }
-
-    // add the last sample
-    sampled_indices.push(y.len() as usize - 1);
-    sampled_indices
-}
 
 #[inline(always)]
-pub(crate) fn fpcs_generic_without_x_parallel<T: PartialOrd + Copy + Send + Sync>(
+pub(crate) fn fpcs_generic_without_x<T: PartialOrd + Copy>(
     arr: &[T],
     n_out: usize,
-    f_argminmax: fn(&[T]) -> (usize, usize),
+    f_minmax: fn(&[T], usize) -> Vec<usize>,
 ) -> Vec<usize> {
-    // --------- 1. parallelize the min-max search
-    // arr.len() -1 is used to match the delta of a range-index (0..arr.len()-1)
-    let block_size: f64 = (arr.len() - 1) as f64 / (n_out - 2) as f64;
-
-    // let mut minmax_idxs: Vec<usize> = Vec::with_capacity((n_out - 2) * 2);
-    let mut minmax_idxs: Vec<usize> = vec![0; (n_out - 2) * 2];
-
-    POOL.install(|| {
-        minmax_idxs
-            .par_chunks_exact_mut(2)
-            .for_each(|min_max_index_chunk| {
-                let i: f64 = unsafe { *min_max_index_chunk.get_unchecked(0) >> 1 } as f64;
-                let start_idx: usize = (block_size * i) as usize + (i != 0.0) as usize;
-                let end_idx: usize = (block_size * (i + 1.0)) as usize + 1;
-
-                let (min_index, max_index) = f_argminmax(&arr[start_idx..end_idx]);
-
-                // Add the indexes in min-max order
-                min_max_index_chunk[0] = min_index + start_idx;
-                min_max_index_chunk[1] = max_index + start_idx;
-            })
-    });
-
-    let mut sampled_indices: Vec<usize> = Vec::with_capacity(n_out * 2);
-
-    let mut previous_min_flag: Flag = Flag::None;
-    let mut potential_point: Point<T> = Point { x: 0, y: arr[0] };
-    let mut max_point: Point<T> = Point { x: 0, y: arr[0] };
-    let mut min_point: Point<T> = Point { x: 0, y: arr[0] };
-
-    // Prepend first and last point
-    sampled_indices.push(0);
-
-    // Process the min/max pairs
-    for chunk in minmax_idxs.chunks(2) {
-        if chunk.len() == 2 {
-            let min_idx = chunk[0];
-            let max_idx = chunk[1];
-
-            fpcs_inner_loop(
-                arr,
-                min_idx,
-                max_idx,
-                &mut min_point,
-                &mut max_point,
-                &mut potential_point,
-                &mut previous_min_flag,
-                &mut sampled_indices,
-            );
-        } else if chunk.len() == 1 {
-            // Handle any remaining single element
-            sampled_indices.push(chunk[0]);
-        }
-    }
-
-    // add the last sample
-    sampled_indices.push(arr.len() as usize - 1);
-    sampled_indices
+    let mut minmax_idxs: Vec<usize> = f_minmax(&arr[1..(arr.len() - 1)], n_out * 2);
+    minmax_idxs.iter_mut().for_each(|elem| *elem += 1); // inplace + 1
+    return fpcs_outer_loop(arr, minmax_idxs, n_out);
 }
+
+// -
+// ------------------------------------- LEGACY --------------------------------------
+// -
 
 pub fn vanilla_fpcs_without_x<Ty: Num + std::cmp::PartialOrd + Copy>(
     y: &[Ty],

--- a/downsample_rs/src/fpcs.rs
+++ b/downsample_rs/src/fpcs.rs
@@ -89,7 +89,7 @@ fn fpcs_outer_loop<Ty: PartialOrd + Copy>(
 
             // NOTE: the minmax_idxs are not ordered!!
             // So we need to check if the min is actually the min
-            if arr[min_idx] >= arr[max_idx] {
+            if arr[min_idx] > arr[max_idx] {
                 min_idx = chunk[1];
                 max_idx = chunk[0];
             }
@@ -225,7 +225,7 @@ pub(crate) fn fpcs_generic<Tx: Num + AsPrimitive<f64>, Ty: PartialOrd + Copy>(
     f_minmax: fn(&[Tx], &[Ty], usize) -> Vec<usize>,
 ) -> Vec<usize> {
     assert_eq!(x.len(), y.len());
-    let mut minmax_idxs = f_minmax(&x[1..(x.len() - 1)], &y[1..(x.len() - 1)], n_out * 2);
+    let mut minmax_idxs = f_minmax(&x[1..(x.len() - 1)], &y[1..(x.len() - 1)], (n_out - 2) * 2);
     minmax_idxs.iter_mut().for_each(|elem| *elem += 1); // inplace + 1
     return fpcs_outer_loop(y, minmax_idxs, n_out);
 }
@@ -238,7 +238,7 @@ pub(crate) fn fpcs_generic_without_x<T: PartialOrd + Copy>(
     n_out: usize,
     f_minmax: fn(&[T], usize) -> Vec<usize>,
 ) -> Vec<usize> {
-    let mut minmax_idxs: Vec<usize> = f_minmax(&arr[1..(arr.len() - 1)], n_out * 2);
+    let mut minmax_idxs: Vec<usize> = f_minmax(&arr[1..(arr.len() - 1)], (n_out - 2) * 2);
     minmax_idxs.iter_mut().for_each(|elem| *elem += 1); // inplace + 1
     return fpcs_outer_loop(arr, minmax_idxs, n_out);
 }

--- a/downsample_rs/src/fpcs.rs
+++ b/downsample_rs/src/fpcs.rs
@@ -2,7 +2,7 @@ use super::minmax;
 use super::types::Num;
 use argminmax::{ArgMinMax, NaNArgMinMax};
 use num_traits::{AsPrimitive, FromPrimitive};
-use std::{fmt::Debug, ops::Not};
+use std::ops::Not;
 
 // ------------------------------- Helper datastructures -------------------------------
 // NOTE: the pub(crate) is added to match the visibility of the fpcs_generic function
@@ -76,7 +76,7 @@ fn fpcs_inner_comp<Ty: PartialOrd + Copy>(
 }
 
 #[inline(always)]
-fn fpcs_outer_loop<Ty: PartialOrd + Copy + Debug>(
+fn fpcs_outer_loop<Ty: PartialOrd + Copy>(
     arr: &[Ty],
     minmax_idxs: Vec<usize>,
     n_out: usize,
@@ -91,7 +91,6 @@ fn fpcs_outer_loop<Ty: PartialOrd + Copy + Debug>(
     // Prepend first point
     sampled_indices.push(0);
 
-    println!("minmax_idxs: {:?}", minmax_idxs);
     // Process the min/max pairs
     for chunk in minmax_idxs.chunks(2) {
         if chunk.len() == 2 {
@@ -136,7 +135,7 @@ macro_rules! fpcs_with_x {
         where
             for<'a> &'a [Ty]: $trait,
             Tx: Num + FromPrimitive + AsPrimitive<f64>,
-            Ty: Copy + PartialOrd + Debug,
+            Ty: Copy + PartialOrd,
         {
             fpcs_generic(x, y, n_out, $f_minmax, $f_fpcs_inner_comp)
         }
@@ -160,7 +159,7 @@ fpcs_with_x!(
 
 macro_rules! fpcs_without_x {
     ($func_name:ident, $trait:path, $f_minmax:expr, $f_fpcs_inner_comp:expr) => {
-        pub fn $func_name<T: Copy + PartialOrd + Debug>(arr: &[T], n_out: usize) -> Vec<usize>
+        pub fn $func_name<T: Copy + PartialOrd>(arr: &[T], n_out: usize) -> Vec<usize>
         where
             for<'a> &'a [T]: $trait,
         {
@@ -192,7 +191,7 @@ macro_rules! fpcs_with_x_parallel {
         where
             for<'a> &'a [Ty]: $trait,
             Tx: Num + FromPrimitive + AsPrimitive<f64> + Send + Sync,
-            Ty: Num + Copy + PartialOrd + Send + Sync + Debug,
+            Ty: Num + Copy + PartialOrd + Send + Sync,
         {
             // collect the parrallel iterator to a vector
             fpcs_generic(x, y, n_out, $f_argminmax, $f_fpcs_inner_comp)
@@ -217,7 +216,7 @@ fpcs_with_x_parallel!(
 
 macro_rules! fpcs_without_x_parallel {
     ($func_name:ident, $trait:path, $f_argminmax:expr, $f_fpcs_inner_comp:expr) => {
-        pub fn $func_name<Ty: Copy + PartialOrd + Send + Sync + Debug>(
+        pub fn $func_name<Ty: Copy + PartialOrd + Send + Sync>(
             arr: &[Ty],
             n_out: usize,
         ) -> Vec<usize>
@@ -248,7 +247,7 @@ fpcs_without_x_parallel!(
 // ----------- WITH X
 
 #[inline(always)]
-pub(crate) fn fpcs_generic<Tx: Num + AsPrimitive<f64>, Ty: PartialOrd + Copy + Debug>(
+pub(crate) fn fpcs_generic<Tx: Num + AsPrimitive<f64>, Ty: PartialOrd + Copy>(
     x: &[Tx],
     y: &[Ty],
     n_out: usize,
@@ -264,7 +263,7 @@ pub(crate) fn fpcs_generic<Tx: Num + AsPrimitive<f64>, Ty: PartialOrd + Copy + D
 // ----------- WITHOUT X
 
 #[inline(always)]
-pub(crate) fn fpcs_generic_without_x<Ty: PartialOrd + Copy + Debug>(
+pub(crate) fn fpcs_generic_without_x<Ty: PartialOrd + Copy>(
     arr: &[Ty],
     n_out: usize,
     f_minmax: fn(&[Ty], usize) -> Vec<usize>,

--- a/downsample_rs/src/lib.rs
+++ b/downsample_rs/src/lib.rs
@@ -11,6 +11,8 @@ pub mod minmaxlttb;
 pub use minmaxlttb::*;
 pub mod m4;
 pub use m4::*;
+pub mod fpcs;
+pub use fpcs::*;
 pub(crate) mod helpers;
 pub(crate) mod searchsorted;
 pub(crate) mod types;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ select = ["E", "F", "I"]
 line-length = 88
 extend-select = ["Q"]
 ignore = ["E402", "F403"]
+ 
+[tool.ruff.per-file-ignores]
+"tsdownsample/_python/downsamplers.py" = ["E501"] # NOTE "downsamplers.py" also works
+
 
 # Formatting
 [tool.black]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,52 @@ fn minmaxlttb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
+// --------------------------------------- FPCS ---------------------------------------
+
+use downsample_rs::fpcs as fpcs_mod;
+
+// Create a sub module for the FPCS algorithm
+#[pymodule]
+fn fpcs(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // ----------------- SEQUENTIAL
+
+    let sequential_mod = PyModule::new_bound(_py, "sequential")?;
+
+    // ----- WITHOUT X
+    {
+        create_pyfuncs_without_x!(fpcs_mod, fpcs_without_x, sequential_mod);
+        create_pyfuncs_without_x!(@nan fpcs_mod, fpcs_without_x_nan, sequential_mod);
+    }
+
+    // ----- WITH X
+    {
+        create_pyfuncs_with_x!(fpcs_mod, fpcs_with_x, sequential_mod);
+        create_pyfuncs_with_x!(@nan fpcs_mod, fpcs_with_x_nan, sequential_mod);
+    }
+
+    // ----------------- PARALLEL
+
+    let parallel_mod = PyModule::new_bound(_py, "parallel")?;
+
+    // ----- WITHOUT X
+    {
+        create_pyfuncs_without_x!(fpcs_mod, fpcs_without_x_parallel, parallel_mod);
+        create_pyfuncs_without_x!(@nan fpcs_mod, fpcs_without_x_parallel_nan, parallel_mod);
+    }
+
+    // ----- WITH X
+    {
+        create_pyfuncs_with_x!(fpcs_mod, fpcs_with_x_parallel, parallel_mod);
+        create_pyfuncs_with_x!(@nan fpcs_mod, fpcs_with_x_parallel_nan, parallel_mod);
+    }
+
+    // Add the sub modules to the module
+    m.add_submodule(&sequential_mod)?;
+    m.add_submodule(&parallel_mod)?;
+
+    Ok(())
+}
+
 // ------------------------------- DOWNSAMPLING MODULE ------------------------------ //
 
 #[pymodule] // The super module
@@ -432,6 +478,7 @@ fn tsdownsample(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(m4))?;
     m.add_wrapped(wrap_pymodule!(lttb))?;
     m.add_wrapped(wrap_pymodule!(minmaxlttb))?;
+    m.add_wrapped(wrap_pymodule!(fpcs))?;
 
     Ok(())
 }

--- a/tests/test_algos_python_compliance.py
+++ b/tests/test_algos_python_compliance.py
@@ -2,20 +2,26 @@ import numpy as np
 import pytest
 
 from tsdownsample import (
-    FPCSDownsampler,  # TODO -> include MinMaxLTTB?
+    FPCSDownsampler,
     LTTBDownsampler,
     M4Downsampler,
     MinMaxDownsampler,
+    # MinMaxLTTBDownsampler,
+    NaNFPCSDownsampler,
     NaNM4Downsampler,
     NaNMinMaxDownsampler,
+    # NaNMinMaxLTTBDownsampler,
 )
 from tsdownsample._python.downsamplers import (
     FPCS_py,
     LTTB_py,
     M4_py,
     MinMax_py,
+    # MinMaxLTTB_py,
+    NaNFPCS_py,
     NaNM4_py,
     NaNMinMax_py,
+    # NaNMinMaxLTTB_py,
 )
 
 
@@ -25,10 +31,13 @@ from tsdownsample._python.downsamplers import (
         (MinMaxDownsampler(), MinMax_py()),
         (M4Downsampler(), M4_py()),
         (LTTBDownsampler(), LTTB_py()),
+        # (MinMaxLTTBDownsampler(), MinMaxLTTB_py()),
         (FPCSDownsampler(), FPCS_py()),
         # Include NaN downsamplers
         (NaNMinMaxDownsampler(), NaNMinMax_py()),
         (NaNM4Downsampler(), NaNM4_py()),
+        # (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
+        (NaNFPCSDownsampler(), NaNFPCS_py()),
     ],
 )
 @pytest.mark.parametrize("n", [10_000, 10_032, 20_321, 23_489])
@@ -51,7 +60,12 @@ def test_resampler_accordance(rust_python_pair, n, n_out):
 
 @pytest.mark.parametrize(
     "rust_python_pair",
-    [(NaNMinMaxDownsampler(), NaNMinMax_py()), (NaNM4Downsampler(), NaNM4_py())],
+    [
+        (NaNMinMaxDownsampler(), NaNMinMax_py()),
+        (NaNM4Downsampler(), NaNM4_py()),
+        # (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
+        (NaNFPCSDownsampler(), NaNFPCS_py()),
+    ],
 )
 @pytest.mark.parametrize("n", [10_000, 10_032, 20_321, 23_489])
 @pytest.mark.parametrize("n_random_nans", [100, 200, 500, 2000, 5000])

--- a/tests/test_algos_python_compliance.py
+++ b/tests/test_algos_python_compliance.py
@@ -84,3 +84,33 @@ def test_nan_resampler_accordance(rust_python_pair, n, n_random_nans, n_out):
         rust_downsampler.downsample(x, y, n_out=n_out),
         python_downsampler.downsample(x, y, n_out=n_out),
     )
+
+
+@pytest.mark.parametrize(
+    "nan_no_nan_pair",
+    [
+        (NaNFPCS_py(), FPCS_py()),
+        (NaNM4_py(), M4_py()),
+        (NaNMinMax_py(), MinMax_py()),
+        (NaNMinMaxLTTB_py(), MinMaxLTTB_py()),
+        (NaNFPCSDownsampler(), FPCSDownsampler()),
+        (NaNM4Downsampler(), M4Downsampler()),
+        (NaNMinMaxDownsampler(), MinMaxDownsampler()),
+        (NaNMinMaxLTTBDownsampler(), MinMaxLTTBDownsampler()),
+    ],
+)
+@pytest.mark.parametrize("n", [10_000, 10_032, 20_321, 23_489])
+@pytest.mark.parametrize("n_out", [100, 200, 252])
+def test_nan_no_nan_resampler_accordance(nan_no_nan_pair, n, n_out):
+    nan_downsampler, no_nan_downsampler = nan_no_nan_pair
+    x = np.arange(n)
+    y = np.random.randn(n)
+    # Wihtout x passed to the downsamplers
+    nan_result = nan_downsampler.downsample(y, n_out=n_out)
+    no_nan_result = no_nan_downsampler.downsample(y, n_out=n_out)
+    assert np.allclose(nan_result, no_nan_result)
+
+    # With x passed to the downsamplers
+    nan_result = nan_downsampler.downsample(x, y, n_out=n_out)
+    no_nan_result = no_nan_downsampler.downsample(x, y, n_out=n_out)
+    assert np.allclose(nan_result, no_nan_result)

--- a/tests/test_algos_python_compliance.py
+++ b/tests/test_algos_python_compliance.py
@@ -6,22 +6,22 @@ from tsdownsample import (
     LTTBDownsampler,
     M4Downsampler,
     MinMaxDownsampler,
-    # MinMaxLTTBDownsampler,
+    MinMaxLTTBDownsampler,
     NaNFPCSDownsampler,
     NaNM4Downsampler,
     NaNMinMaxDownsampler,
-    # NaNMinMaxLTTBDownsampler,
+    NaNMinMaxLTTBDownsampler,
 )
 from tsdownsample._python.downsamplers import (
     FPCS_py,
     LTTB_py,
     M4_py,
     MinMax_py,
-    # MinMaxLTTB_py,
+    MinMaxLTTB_py,
     NaNFPCS_py,
     NaNM4_py,
     NaNMinMax_py,
-    # NaNMinMaxLTTB_py,
+    NaNMinMaxLTTB_py,
 )
 
 
@@ -31,12 +31,12 @@ from tsdownsample._python.downsamplers import (
         (MinMaxDownsampler(), MinMax_py()),
         (M4Downsampler(), M4_py()),
         (LTTBDownsampler(), LTTB_py()),
-        # (MinMaxLTTBDownsampler(), MinMaxLTTB_py()),
+        (MinMaxLTTBDownsampler(), MinMaxLTTB_py()),
         (FPCSDownsampler(), FPCS_py()),
         # Include NaN downsamplers
         (NaNMinMaxDownsampler(), NaNMinMax_py()),
         (NaNM4Downsampler(), NaNM4_py()),
-        # (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
+        (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
         (NaNFPCSDownsampler(), NaNFPCS_py()),
     ],
 )
@@ -63,7 +63,7 @@ def test_resampler_accordance(rust_python_pair, n, n_out):
     [
         (NaNMinMaxDownsampler(), NaNMinMax_py()),
         (NaNM4Downsampler(), NaNM4_py()),
-        # (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
+        (NaNMinMaxLTTBDownsampler(), NaNMinMaxLTTB_py()),
         (NaNFPCSDownsampler(), NaNFPCS_py()),
     ],
 )

--- a/tests/test_algos_python_compliance.py
+++ b/tests/test_algos_python_compliance.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from tsdownsample import (
+    FPCSDownsampler,  # TODO -> include MinMaxLTTB?
     LTTBDownsampler,
     M4Downsampler,
     MinMaxDownsampler,
@@ -9,6 +10,7 @@ from tsdownsample import (
     NaNMinMaxDownsampler,
 )
 from tsdownsample._python.downsamplers import (
+    FPCS_py,
     LTTB_py,
     M4_py,
     MinMax_py,
@@ -23,6 +25,7 @@ from tsdownsample._python.downsamplers import (
         (MinMaxDownsampler(), MinMax_py()),
         (M4Downsampler(), M4_py()),
         (LTTBDownsampler(), LTTB_py()),
+        (FPCSDownsampler(), FPCS_py()),
         # Include NaN downsamplers
         (NaNMinMaxDownsampler(), NaNMinMax_py()),
         (NaNM4Downsampler(), NaNM4_py()),

--- a/tests/test_tsdownsample.py
+++ b/tests/test_tsdownsample.py
@@ -6,10 +6,12 @@ from test_config import supported_dtypes_x, supported_dtypes_y
 
 from tsdownsample import (  # MeanDownsampler,; MedianDownsampler,
     EveryNthDownsampler,
+    FPCSDownsampler,
     LTTBDownsampler,
     M4Downsampler,
     MinMaxDownsampler,
     MinMaxLTTBDownsampler,
+    NaNFPCSDownsampler,
     NaNM4Downsampler,
     NaNMinMaxDownsampler,
     NaNMinMaxLTTBDownsampler,
@@ -28,12 +30,14 @@ RUST_DOWNSAMPLERS = [
     M4Downsampler(),
     LTTBDownsampler(),
     MinMaxLTTBDownsampler(),
+    FPCSDownsampler(),
 ]
 
 RUST_NAN_DOWNSAMPLERS = [
     NaNMinMaxDownsampler(),
     NaNM4Downsampler(),
     NaNMinMaxLTTBDownsampler(),
+    NaNFPCSDownsampler(),
 ]
 
 OTHER_DOWNSAMPLERS = [EveryNthDownsampler()]
@@ -167,8 +171,12 @@ def test_downsampling_with_gaps_in_x(downsampler: AbstractDownsampler):
     idx = np.arange(len(arr))
     idx[: len(idx) // 2] += len(idx) // 2  # add large gap in x
     s_downsampled = downsampler.downsample(idx, arr, n_out=100)
-    assert len(s_downsampled) <= 100
-    assert len(s_downsampled) >= 66
+    if "FPCS" in downsampler.__class__.__name__:
+        assert len(s_downsampled) >= 100
+        assert len(s_downsampled) <= 200
+    else:
+        assert len(s_downsampled) <= 100
+        assert len(s_downsampled) >= 66
 
 
 @pytest.mark.parametrize("downsampler", generate_rust_downsamplers())

--- a/tsdownsample/__init__.py
+++ b/tsdownsample/__init__.py
@@ -2,10 +2,12 @@
 
 from .downsamplers import (
     EveryNthDownsampler,
+    FPCSDownsampler,
     LTTBDownsampler,
     M4Downsampler,
     MinMaxDownsampler,
     MinMaxLTTBDownsampler,
+    NaNFPCSDownsampler,
     NaNM4Downsampler,
     NaNMinMaxDownsampler,
     NaNMinMaxLTTBDownsampler,
@@ -16,10 +18,12 @@ __author__ = "Jeroen Van Der Donckt"
 
 __all__ = [
     "EveryNthDownsampler",
+    "FPCSDownsampler",
     "MinMaxDownsampler",
     "M4Downsampler",
     "LTTBDownsampler",
     "MinMaxLTTBDownsampler",
+    "NaNFPCSDownsampler",
     "NaNMinMaxDownsampler",
     "NaNM4Downsampler",
     "NaNMinMaxLTTBDownsampler",

--- a/tsdownsample/_python/downsamplers.py
+++ b/tsdownsample/_python/downsamplers.py
@@ -1,10 +1,10 @@
+from abc import ABC
 from enum import Enum
 from typing import NamedTuple, Union
 
 import numpy as np
 
 from ..downsampling_interface import AbstractDownsampler
-from abc import ABC
 
 
 def _get_bin_idxs(x: np.ndarray, nb_bins: int) -> np.ndarray:

--- a/tsdownsample/_python/downsamplers.py
+++ b/tsdownsample/_python/downsamplers.py
@@ -93,7 +93,7 @@ class LTTB_py(AbstractDownsampler):
                 LTTB_py._argmax_area(
                     prev_x=x[a],
                     prev_y=y[a],
-                    # NOTE: In a 100% correct implementation of LTTB the next x average 
+                    # NOTE: In a 100% correct implementation of LTTB the next x average
                     # should be implemented as the following:
                     # avg_next_x=np.mean(x[offset[i + 1] : offset[i + 2]]),
                     # To improve performance we use the following approximation

--- a/tsdownsample/downsamplers.py
+++ b/tsdownsample/downsamplers.py
@@ -136,6 +136,36 @@ class NaNMinMaxLTTBDownsampler(AbstractRustNaNDownsampler):
         )
 
 
+class FPCSDownsampler(AbstractRustDownsampler):
+    """Downsampler that uses the Feature Preserving Compensated Sampling (FPCS)
+    algorithm.
+
+    FPCS paper: https://doi.org/10.1109/TVCG.2024.3456375
+    """
+
+    @property
+    def rust_mod(self):
+        return _tsdownsample_rs.fpcs
+
+    def downsample(self, *args, n_out: int, parallel: bool = False, **_):
+        return super().downsample(*args, n_out=n_out, parallel=parallel)
+
+
+class NaNFPCSDownsampler(AbstractRustNaNDownsampler):
+    """Downsampler that uses the Feature Preserving Compensated Sampling (FPCS)
+     algorithm. If the y data contains NaNs, the indices of these NaNs are returned.
+
+    FPCS paper: https://doi.org/10.1109/TVCG.2024.3456375
+    """
+
+    @property
+    def rust_mod(self):
+        return _tsdownsample_rs.fpcs
+
+    def downsample(self, *args, n_out: int, parallel: bool = False, **_):
+        return super().downsample(*args, n_out=n_out, parallel=parallel)
+
+
 # ------------------ EveryNth Downsampler ------------------
 
 


### PR DESCRIPTION
This PR ports the Feature-Preserving Compensated Sampling algorithm to tsdownsample

https://ieeexplore.ieee.org/document/10669793

DONE:
- [x] tests for fpcs
- [x] (compare with vanilla python / rust implementation)
- [x] Nan handling
- [x] add test for same behavior for nan- and non-nan aggregators when no nans are present in the data 

TODO:
- [ ] .rs tests
- [ ] analyze current `fpcs.rs` file (and mainly the macro, as I separated the `fpcs_inner_comp`) function.