### PR TITLE
feat: add support for Python 3.14

### DIFF
--- a/.github/workflows/ci-tsdownsample.yml
+++ b/.github/workflows/ci-tsdownsample.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-latest']
         rust: ['nightly']  # ['stable', 'beta']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', "3.13"]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', "3.13", "3.14"]
     
     env:
       PYTHON: ${{ matrix.python-version }}
@@ -155,7 +155,7 @@ jobs:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
         container: ${{ matrix.container }}
-        args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13' }}
+        args: --release --out dist --interpreter ${{ matrix.interpreter || '3.8 3.9 3.10 3.11 3.12 3.13 3.14' }}
 
     - run: ${{ matrix.ls || 'ls -lh' }} dist/
 

--- a/.github/workflows/ci-tsdownsample.yml
+++ b/.github/workflows/ci-tsdownsample.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: ['windows-latest', 'macOS-latest', 'ubuntu-latest']
         rust: ['nightly']  # ['stable', 'beta']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', "3.13", "3.14"]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 
 [dependencies]
 downsample_rs = { path = "downsample_rs", features = ["half"]}
-pyo3 = { version = "0.22", features = ["extension-module"] }
-numpy = { version = "0.22", features = ["half"] }
+pyo3 = { version = "0.26", features = ["extension-module"] }
+numpy = { version = "0.26", features = ["half"] }
 half = { version = "2.3.1", default-features = false }
 paste = { version = "1.0.14", default-features = false }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,10 @@ module-name = "tsdownsample._rust._tsdownsample_rs" # The path to place the comp
 
 # Linting
 [tool.ruff]
-select = ["E", "F", "I"]
 line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
 extend-select = ["Q"]
 ignore = ["E402", "F403"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Operating System :: POSIX',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ macro_rules! _create_pyfunc_without_x {
         ) -> Bound<'py, PyArray1<usize>> {
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(y, n_out);
-            sampled_indices.into_pyarray_bound(py)
+            sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
         $mod.add_wrapped(wrap_pyfunction!($name))?;
@@ -44,7 +44,7 @@ macro_rules! _create_pyfunc_without_x_with_ratio {
         ) -> Bound<'py, PyArray1<usize>> {
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(y, n_out, ratio);
-            sampled_indices.into_pyarray_bound(py)
+            sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
         $mod.add_wrapped(wrap_pyfunction!($name))?;
@@ -84,7 +84,7 @@ macro_rules! _create_pyfunc_with_x {
             let x = x.as_slice().unwrap();
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(x, y, n_out);
-            sampled_indices.into_pyarray_bound(py)
+            sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
         $mod.add_wrapped(wrap_pyfunction!($name))?;
@@ -105,7 +105,7 @@ macro_rules! _create_pyfunc_with_x_with_ratio {
             let x = x.as_slice().unwrap();
             let y = y.as_slice().unwrap();
             let sampled_indices = $resample_mod::$resample_fn(x, y, n_out, ratio);
-            sampled_indices.into_pyarray_bound(py)
+            sampled_indices.into_pyarray(py)
         }
         // Add the function to the module
         $mod.add_wrapped(wrap_pyfunction!($name))?;
@@ -258,7 +258,7 @@ use downsample_rs::minmax as minmax_mod;
 fn minmax(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // ----------------- SEQUENTIAL
 
-    let sequential_mod = PyModule::new_bound(_py, "sequential")?;
+    let sequential_mod = PyModule::new(_py, "sequential")?;
 
     // ----- WITHOUT X
     {
@@ -274,7 +274,7 @@ fn minmax(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // ----------------- PARALLEL
 
-    let parallel_mod = PyModule::new_bound(_py, "parallel")?;
+    let parallel_mod = PyModule::new(_py, "parallel")?;
 
     // ----- WITHOUT X
     {
@@ -304,7 +304,7 @@ use downsample_rs::m4 as m4_mod;
 fn m4(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // ----------------- SEQUENTIAL
 
-    let sequential_mod = PyModule::new_bound(_py, "sequential")?;
+    let sequential_mod = PyModule::new(_py, "sequential")?;
 
     // ----- WITHOUT X
     {
@@ -320,7 +320,7 @@ fn m4(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // ----------------- PARALLEL
 
-    let parallel_mod = PyModule::new_bound(_py, "parallel")?;
+    let parallel_mod = PyModule::new(_py, "parallel")?;
 
     // ----- WITHOUT X
     {
@@ -350,7 +350,7 @@ use downsample_rs::lttb as lttb_mod;
 fn lttb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // ----------------- SEQUENTIAL
 
-    let sequential_mod = PyModule::new_bound(_py, "sequential")?;
+    let sequential_mod = PyModule::new(_py, "sequential")?;
 
     // Create the Python functions for the module
     // ----- WITHOUT X
@@ -378,7 +378,7 @@ use downsample_rs::minmaxlttb as minmaxlttb_mod;
 fn minmaxlttb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // ----------------- SEQUENTIAL
 
-    let sequential_mod = PyModule::new_bound(_py, "sequential")?;
+    let sequential_mod = PyModule::new(_py, "sequential")?;
 
     // ----- WITHOUT X
     {
@@ -394,7 +394,7 @@ fn minmaxlttb(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // ----------------- PARALLEL
 
-    let parallel_mod = PyModule::new_bound(_py, "parallel")?;
+    let parallel_mod = PyModule::new(_py, "parallel")?;
 
     // ----- WITHOUT X
     {

--- a/tests/test_rust_mods.py
+++ b/tests/test_rust_mods.py
@@ -1,10 +1,9 @@
+import tsdownsample._rust._tsdownsample_rs as tsds_rs
 from test_config import (
     rust_primitive_types_x,
     rust_primitive_types_y,
     rust_primitive_types_y_nan,
 )
-
-import tsdownsample._rust._tsdownsample_rs as tsds_rs
 
 
 def _test_rust_mod_correctly_build(mod, sub_mods, has_x_impl: bool):


### PR DESCRIPTION
Co-authored by: Dimitris Iliopoulos <dimitris.iliopoulos@gmail.com>

This PR adds support for Python 3.14 by bumping the pyo3 and rust-numpy dependencies to version 0.26. This requires a small refactor to the source code. These changes are identical to those made by @diliop in https://github.com/predict-idlab/tsdownsample/pull/85, so I've added them as a co-author to recognise their contribution.

Closes https://github.com/predict-idlab/tsdownsample/issues/87